### PR TITLE
Fix all 41 findings from the whole-repo review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,13 @@ jobs:
       - run: zig build -Doptimize=ReleaseSafe
       - run: zig build release
       - run: zig build gen
+      - name: Check generated completions
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -qq -y zsh fish
+          bash -n zig-out/gen/hcibridge.bash
+          zsh -n zig-out/gen/_hcibridge
+          fish --no-execute zig-out/gen/hcibridge.fish
       - name: Package smoke test (deb/rpm/apk)
         run: |
           NV=2.44.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,10 +114,12 @@ jobs:
               PKG_ARCH="$arch" nfpm pkg -f packaging/nfpm.yaml -p "$fmt" -t out/
             done
           done
-          # AUR PKGBUILD and Alpine APKBUILD with version + source checksum
-          SHA=$(curl -sL "https://github.com/heppu/esp-hci-bridge/archive/refs/tags/${GITHUB_REF_NAME}.tar.gz" | sha256sum | cut -d' ' -f1)
+          # AUR PKGBUILD, Alpine APKBUILD and Void template with version + source checksum
+          curl -sSfL -o src.tar.gz "https://github.com/heppu/esp-hci-bridge/archive/refs/tags/${GITHUB_REF_NAME}.tar.gz"
+          SHA=$(sha256sum src.tar.gz | cut -d' ' -f1)
+          SHA512=$(sha512sum src.tar.gz | cut -d' ' -f1)
           sed -e "s/@PKGVER@/$VER/" -e "s/@SHA256@/$SHA/" packaging/PKGBUILD.tmpl > out/PKGBUILD
-          sed -e "s/@PKGVER@/$VER/" packaging/APKBUILD.tmpl > out/APKBUILD
+          sed -e "s/@PKGVER@/$VER/" -e "s/@SHA512@/$SHA512/" packaging/APKBUILD.tmpl > out/APKBUILD
           sed -e "s/@PKGVER@/$VER/" -e "s/@SHA256@/$SHA/" packaging/void-template.tmpl > out/void-template
           ls -1 out/
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -144,13 +146,15 @@ jobs:
       - name: Assemble assets
         run: |
           mkdir -p release
-          # per-board firmware images, named by board
+          # app image and bootloader differ per board, partition table and OTA data do not
           for b in olimex-esp32-poe wt32-eth01 generic-wifi; do
             cp "_site/firmware/$b/esp-hci-bridge.bin" "release/esp-hci-bridge-$b.bin"
-            cp "_site/manifest-$b.json" "release/manifest-$b.json"
+            cp "_site/firmware/$b/bootloader.bin" "release/bootloader-$b.bin"
+            for f in partition-table.bin ota_data_initial.bin; do
+              [ -f "_site/firmware/$b/$f" ] || continue
+              if [ -f "release/$f" ]; then cmp "_site/firmware/$b/$f" "release/$f"; else cp "_site/firmware/$b/$f" release/; fi
+            done
           done
-          # shared bootloader/partition table are identical across boards
-          cp _site/firmware/olimex-esp32-poe/bootloader.bin _site/firmware/olimex-esp32-poe/partition-table.bin release/
           cp cli/* release/
           chmod +x release/hcibridge-*
           cd release && sha256sum * > SHA256SUMS && cat SHA256SUMS

--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ WiFi boards with no saved network start a setup hotspot on first boot: join
 `esp-hci-bridge-setup` from your phone or laptop, open `http://192.168.4.1/`,
 enter your WiFi name and password. The board reboots onto your network.
 
-(Prefer the terminal? Every [release](https://github.com/heppu/esp-hci-bridge/releases/latest)
-also has the raw `.bin` files and an `esptool` command.)
+(Prefer the terminal? The web flasher page lists every `.bin` for your board
+with its flash offset and a ready `esptool` command. Releases carry the same
+files as `esp-hci-bridge-<board>.bin`, `bootloader-<board>.bin`,
+`partition-table.bin`, and `ota_data_initial.bin`.)
 
 ### 2. Install on your PC
 
@@ -104,12 +106,15 @@ fish, all installed by the package.
 
 ### Updating firmware
 
-No cable needed after the first flash. Download the new `esp-hci-bridge.bin`
-from a release and:
+No cable needed after the first flash. Download the new
+`esp-hci-bridge-<board>.bin` for your board from a release and:
 
 ```sh
-hcibridge update all esp-hci-bridge.bin
+hcibridge update all esp-hci-bridge-olimex-esp32-poe.bin
 ```
+
+`update all` sends that one image to every board it finds, so if you run more
+than one board type, update each board by IP with its own image instead.
 
 Boards keep two firmware slots and roll back automatically if an update fails to
 come online. Updates are only accepted from the PC that claimed the board, and
@@ -278,6 +283,11 @@ probes. TCP keepalive drops a dead peer in about ten seconds.
 
 ## Status
 
+> **Upgrading from v0.10.0 to v0.10.2?** Those releases shipped broken zsh and
+> fish completions and, on rpm, a preremove script that stopped and disabled the
+> service on every upgrade. After upgrading to v0.10.3 on rpm, run
+> `systemctl enable --now hcibridge` once.
+>
 > **Upgrading from v0.9.0?** That release could not confirm an OTA-installed
 > image, so boards updated *onto* v0.9.0 refuse further updates and roll back
 > on reset. Power-cycle the board once (it returns to its previous firmware),

--- a/common/auth.zig
+++ b/common/auth.zig
@@ -56,35 +56,78 @@ pub fn boardMac(psk: *const Psk, client_nonce: *const Nonce, server_nonce: *cons
 }
 
 // ---------------------------------------------------------------------------
-// Announce signature: hex of first 16 bytes of HMAC(psk, "bdaddr\tport\tname").
+// Announce signature: hex of first 16 bytes of
+// HMAC(psk, "bdaddr\tport\tname\ta.b.c.d") where a.b.c.d is the board's own
+// IPv4 address. The host checks it against the datagram source, so a captured
+// announce cannot be replayed from another machine.
 // ---------------------------------------------------------------------------
 
-pub fn announceSig(psk: *const Psk, bdaddr: []const u8, port: u16, name: []const u8, out: *[announce_sig_hex_len]u8) []const u8 {
+pub fn announceSig(psk: *const Psk, bdaddr: []const u8, port: u16, name: []const u8, ip: [4]u8, out: *[announce_sig_hex_len]u8) []const u8 {
     var pbuf: [8]u8 = undefined;
     const port_s = std.fmt.bufPrint(&pbuf, "{d}", .{port}) catch unreachable;
-    const m = hmac(psk, &.{ bdaddr, "\t", port_s, "\t", name });
+    var ibuf: [16]u8 = undefined;
+    const ip_s = std.fmt.bufPrint(&ibuf, "{d}.{d}.{d}.{d}", .{ ip[0], ip[1], ip[2], ip[3] }) catch unreachable;
+    const m = hmac(psk, &.{ bdaddr, "\t", port_s, "\t", name, "\t", ip_s });
     const hex = std.fmt.bytesToHex(m[0..16], .lower);
     @memcpy(out, &hex);
     return out;
 }
 
-pub fn verifyAnnounce(psk: *const Psk, bdaddr: []const u8, port: u16, name: []const u8, sig: []const u8) bool {
+pub fn verifyAnnounce(psk: *const Psk, bdaddr: []const u8, port: u16, name: []const u8, ip: [4]u8, sig: []const u8) bool {
     var expect: [announce_sig_hex_len]u8 = undefined;
-    _ = announceSig(psk, bdaddr, port, name, &expect);
+    _ = announceSig(psk, bdaddr, port, name, ip, &expect);
     return ctEqual(&expect, sig);
 }
 
 // ---------------------------------------------------------------------------
-// HTTP auth header: hex(HMAC(psk, "<METHOD> <path>\n" || SHA256(body)))
+// HTTP proofs. The board publishes a nonce in its status JSON: 16 random bytes
+// chosen at boot followed by a big-endian 32-bit counter that advances after
+// every accepted request, so a captured proof is dead after it is used once.
+//
+//   X-Bridge-Auth: hex(HMAC(psk, "<METHOD> <path>\n" || nonce || SHA256(body)))
+//   X-Bridge-Pre:  hex(HMAC(psk, "PRE <METHOD> <path>\n" || nonce || be32(content_length)))
+//
+// Pre is checked before the body is read, so an upload without the key never
+// touches flash. Auth is checked after the body, before the image is activated.
 // ---------------------------------------------------------------------------
 
-pub fn httpAuth(psk: *const Psk, method: []const u8, path: []const u8, body: []const u8, out: *[mac_len * 2]u8) []const u8 {
+pub const http_nonce_len = 20;
+pub const HttpNonce = [http_nonce_len]u8;
+
+pub fn httpAuth(psk: *const Psk, method: []const u8, path: []const u8, nonce: *const HttpNonce, body: []const u8, out: *[mac_len * 2]u8) []const u8 {
+    var digest: [Sha256.digest_length]u8 = undefined;
+    Sha256.hash(body, &digest, .{});
+    const m = hmac(psk, &.{ method, " ", path, "\n", nonce, &digest });
+    const hex = std.fmt.bytesToHex(m, .lower);
+    @memcpy(out, &hex);
+    return out;
+}
+
+pub fn httpPre(psk: *const Psk, method: []const u8, path: []const u8, nonce: *const HttpNonce, content_len: u32, out: *[mac_len * 2]u8) []const u8 {
+    var len_be: [4]u8 = undefined;
+    std.mem.writeInt(u32, &len_be, content_len, .big);
+    const m = hmac(psk, &.{ "PRE ", method, " ", path, "\n", nonce, &len_be });
+    const hex = std.fmt.bytesToHex(m, .lower);
+    @memcpy(out, &hex);
+    return out;
+}
+
+/// Proof format of firmware before v0.10.3 (no nonce, replayable). Only used to
+/// push a fixed image onto boards that still run it.
+pub fn httpAuthLegacy(psk: *const Psk, method: []const u8, path: []const u8, body: []const u8, out: *[mac_len * 2]u8) []const u8 {
     var digest: [Sha256.digest_length]u8 = undefined;
     Sha256.hash(body, &digest, .{});
     const m = hmac(psk, &.{ method, " ", path, "\n", &digest });
     const hex = std.fmt.bytesToHex(m, .lower);
     @memcpy(out, &hex);
     return out;
+}
+
+pub fn hexToNonce(hex: []const u8) ?HttpNonce {
+    if (hex.len != http_nonce_len * 2) return null;
+    var n: HttpNonce = undefined;
+    _ = std.fmt.hexToBytes(&n, hex) catch return null;
+    return n;
 }
 
 // ---------------------------------------------------------------------------
@@ -134,10 +177,12 @@ test "handshake macs verify and are direction-bound" {
 test "announce sign/verify" {
     const psk: Psk = [_]u8{9} ** 32;
     var sig: [announce_sig_hex_len]u8 = undefined;
-    _ = announceSig(&psk, "a0:a3:b3:2f:61:1e", 4444, "esp-hci-bridge", &sig);
-    try testing.expect(verifyAnnounce(&psk, "a0:a3:b3:2f:61:1e", 4444, "esp-hci-bridge", &sig));
-    try testing.expect(!verifyAnnounce(&psk, "a0:a3:b3:2f:61:1e", 4445, "esp-hci-bridge", &sig));
-    try testing.expect(!verifyAnnounce(&psk, "a0:a3:b3:2f:61:1e", 4444, "evil", &sig));
+    _ = announceSig(&psk, "a0:a3:b3:2f:61:1e", 4444, "esp-hci-bridge", .{ 172, 16, 135, 242 }, &sig);
+    const ip: [4]u8 = .{ 172, 16, 135, 242 };
+    try testing.expect(verifyAnnounce(&psk, "a0:a3:b3:2f:61:1e", 4444, "esp-hci-bridge", ip, &sig));
+    try testing.expect(!verifyAnnounce(&psk, "a0:a3:b3:2f:61:1e", 4445, "esp-hci-bridge", ip, &sig));
+    try testing.expect(!verifyAnnounce(&psk, "a0:a3:b3:2f:61:1e", 4444, "evil", ip, &sig));
+    try testing.expect(!verifyAnnounce(&psk, "a0:a3:b3:2f:61:1e", 4444, "esp-hci-bridge", .{ 172, 16, 135, 243 }, &sig));
 }
 
 test "claim derives the same psk on both sides" {

--- a/common/auth.zig
+++ b/common/auth.zig
@@ -201,3 +201,44 @@ test "psk hex round trip" {
     try testing.expectEqualSlices(u8, &psk, &(hexToPsk(&hex).?));
     try testing.expect(hexToPsk("short") == null);
 }
+
+// Known answers computed with Python hmac/hashlib. If the firmware and this
+// file ever disagree, one of them changed the byte layout.
+const kat_psk: Psk = [_]u8{0x42} ** 32;
+const kat_server_nonce: Nonce = [_]u8{0x01} ** 32;
+const kat_client_nonce: Nonce = [_]u8{0x02} ** 32;
+const kat_http_nonce: HttpNonce = .{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 };
+
+test "clientMac known answer" {
+    const m = clientMac(&kat_psk, &kat_server_nonce, &kat_client_nonce);
+    try testing.expectEqualStrings("2fe39892c5e63ee8db176f30fc167c6dca28c3c7b6de9f282db5a6cb19c469fb", &std.fmt.bytesToHex(m, .lower));
+}
+
+test "boardMac known answer" {
+    const m = boardMac(&kat_psk, &kat_client_nonce, &kat_server_nonce);
+    try testing.expectEqualStrings("1b4c57c4b9475964807cb64cb09f4e9e8b965e528879dffe7da6b16e5bc760c3", &std.fmt.bytesToHex(m, .lower));
+}
+
+test "announceSig known answer" {
+    var sig: [announce_sig_hex_len]u8 = undefined;
+    _ = announceSig(&kat_psk, "a0:a3:b3:2f:61:1e", 4444, "esp-hci-bridge", .{ 172, 16, 135, 242 }, &sig);
+    try testing.expectEqualStrings("f31c4827ed4d937c2384e8e08b99cf52", &sig);
+}
+
+test "httpAuth known answer" {
+    var mac: [mac_len * 2]u8 = undefined;
+    _ = httpAuth(&kat_psk, "POST", "/ota", &kat_http_nonce, "hello", &mac);
+    try testing.expectEqualStrings("d73a6fdc38fd0d275ea4598553abf13d07f8faee5edacb4a6e8d5ecf968a2d6b", &mac);
+}
+
+test "httpPre known answer" {
+    var mac: [mac_len * 2]u8 = undefined;
+    _ = httpPre(&kat_psk, "POST", "/ota", &kat_http_nonce, 5, &mac);
+    try testing.expectEqualStrings("8a27ffcc95c766a804fdb997ada1fd22f1dcc3b09fbe676250823a8e6b04f0b1", &mac);
+}
+
+test "httpAuthLegacy known answer" {
+    var mac: [mac_len * 2]u8 = undefined;
+    _ = httpAuthLegacy(&kat_psk, "POST", "/ota", "hello", &mac);
+    try testing.expectEqualStrings("a5a0c35d2853c43b6c49d62f9e96b169c90907f876817ccd96505fe92ad2a72f", &mac);
+}

--- a/common/h4.zig
+++ b/common/h4.zig
@@ -251,3 +251,26 @@ test "zero length payloads" {
 test "iso length masks reserved bits" {
     try testing.expectEqual(@as(usize, 3), PacketType.iso.payloadLen(&.{ 0x02, 0x00, 0x03, 0x40 }));
 }
+
+test "packet exactly filling storage is accepted, one byte over is not" {
+    var storage: [16]u8 = undefined;
+    var re = Reassembler.init(&storage);
+    const fits = [_]u8{ 0x02, 0x40, 0x20, 11, 0x00 } ++ [_]u8{0xaa} ** 11;
+    const r = try re.feed(&fits);
+    try testing.expectEqual(fits.len, r.consumed);
+    try testing.expectEqualSlices(u8, &fits, r.packet.?);
+
+    const over = [_]u8{ 0x02, 0x40, 0x20, 12, 0x00 } ++ [_]u8{0xbb} ** 12;
+    try testing.expectError(error.PacketTooLarge, re.feed(&over));
+}
+
+test "reset recovers after PacketTooLarge" {
+    var storage: [16]u8 = undefined;
+    var re = Reassembler.init(&storage);
+    const over = [_]u8{ 0x02, 0x40, 0x20, 12, 0x00 };
+    try testing.expectError(error.PacketTooLarge, re.feed(&over));
+    try testing.expectError(error.PacketTooLarge, re.feed(&reset_cmd));
+    re.reset();
+    const r = try re.feed(&reset_cmd);
+    try testing.expectEqualSlices(u8, &reset_cmd, r.packet.?);
+}

--- a/firmware/main/auth.c
+++ b/firmware/main/auth.c
@@ -7,6 +7,7 @@
 #include "esp_err.h"
 #include "esp_log.h"
 #include "esp_random.h"
+#include "esp_timer.h"
 #include "lwip/sockets.h"
 #include "mbedtls/ecdh.h"
 #include "mbedtls/ecp.h"
@@ -19,11 +20,15 @@ static const char *TAG = "auth";
 #define PSK_LEN 32
 #define NONCE_LEN 32
 #define MAC_LEN 32
+#define HTTP_NONCE_LEN 20
+#define HANDSHAKE_DEADLINE_US (5 * 1000000LL)
 static const char DOM_CLIENT[] = "esp-hci-client";
 static const char DOM_BOARD[] = "esp-hci-board";
 
 static uint8_t g_psk[PSK_LEN];
 static bool g_claimed = false;
+static uint8_t g_http_rand[16];
+static uint32_t g_http_counter = 0;
 
 static int rng(void *ctx, unsigned char *out, size_t len)
 {
@@ -54,6 +59,7 @@ static bool hmac_parts(const uint8_t *key, size_t klen, const uint8_t *const *pa
 
 bool auth_init(void)
 {
+    esp_fill_random(g_http_rand, sizeof(g_http_rand));
     nvs_handle_t h;
     if (nvs_open("bridge", NVS_READONLY, &h) == ESP_OK) {
         size_t len = PSK_LEN;
@@ -94,10 +100,14 @@ static int unhex(const char *s, size_t n, uint8_t *out)
 
 // --- HCI socket handshake ---------------------------------------------------
 
-static bool recv_exact(int fd, uint8_t *buf, size_t n)
+static bool recv_exact(int fd, uint8_t *buf, size_t n, int64_t deadline_us)
 {
     size_t got = 0;
     while (got < n) {
+        int64_t left = deadline_us - esp_timer_get_time();
+        if (left <= 0) return false;
+        struct timeval tv = { .tv_sec = left / 1000000, .tv_usec = left % 1000000 };
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
         int r = recv(fd, buf + got, n - got, 0);
         if (r <= 0) return false;
         got += (size_t)r;
@@ -105,21 +115,14 @@ static bool recv_exact(int fd, uint8_t *buf, size_t n)
     return true;
 }
 
-bool auth_handshake(int fd)
+static bool handshake_inner(int fd, int64_t deadline_us)
 {
-    if (!g_claimed) {
-        ESP_LOGW(TAG, "refusing HCI connection: board unclaimed");
-        return false;
-    }
-    struct timeval tv = { .tv_sec = 3, .tv_usec = 0 };
-    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
-
     uint8_t sn[NONCE_LEN];
     esp_fill_random(sn, sizeof(sn));
     if (send(fd, sn, sizeof(sn), 0) != (int)sizeof(sn)) return false;
 
     uint8_t msg[NONCE_LEN + MAC_LEN];
-    if (!recv_exact(fd, msg, sizeof(msg))) return false;
+    if (!recv_exact(fd, msg, sizeof(msg), deadline_us)) return false;
     const uint8_t *cn = msg;
     const uint8_t *cmac = msg + NONCE_LEN;
 
@@ -136,18 +139,27 @@ bool auth_handshake(int fd)
     const uint8_t *p2[] = { cn, sn, (const uint8_t *)DOM_BOARD };
     const size_t l2[] = { NONCE_LEN, NONCE_LEN, sizeof(DOM_BOARD) - 1 };
     if (!hmac_parts(g_psk, PSK_LEN, p2, l2, 3, bmac)) return false;
-    if (send(fd, bmac, sizeof(bmac), 0) != (int)sizeof(bmac)) return false;
+    return send(fd, bmac, sizeof(bmac), 0) == (int)sizeof(bmac);
+}
 
-    // Back to blocking for the HCI pump.
-    tv.tv_sec = 0;
+// The whole exchange must finish within one deadline so a peer trickling
+// bytes cannot hold the rx task.
+bool auth_handshake(int fd)
+{
+    if (!g_claimed) {
+        ESP_LOGW(TAG, "refusing HCI connection: board unclaimed");
+        return false;
+    }
+    bool ok = handshake_inner(fd, esp_timer_get_time() + HANDSHAKE_DEADLINE_US);
+    struct timeval tv = { 0 };
     setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
-    return true;
+    return ok;
 }
 
 // --- discovery announce signature -------------------------------------------
 
-// hex of first 16 bytes of HMAC(psk, "bdaddr\tport\tname"), or "-" if unclaimed.
-size_t auth_announce_sig(const char *bdaddr, unsigned port, const char *name, char *out, size_t outlen)
+// hex of first 16 bytes of HMAC(psk, "bdaddr\tport\tname\tip"), or "-" if unclaimed.
+size_t auth_announce_sig(const char *bdaddr, unsigned port, const char *name, const char *ip, char *out, size_t outlen)
 {
     if (!g_claimed || outlen < 33) {
         if (outlen >= 2) { out[0] = '-'; out[1] = '\0'; }
@@ -156,26 +168,70 @@ size_t auth_announce_sig(const char *bdaddr, unsigned port, const char *name, ch
     char ps[8];
     int pn = snprintf(ps, sizeof(ps), "%u", port);
     uint8_t mac[MAC_LEN];
-    const uint8_t *p[] = { (const uint8_t *)bdaddr, (const uint8_t *)"\t", (const uint8_t *)ps, (const uint8_t *)"\t", (const uint8_t *)name };
-    const size_t l[] = { strlen(bdaddr), 1, (size_t)pn, 1, strlen(name) };
-    if (!hmac_parts(g_psk, PSK_LEN, p, l, 5, mac)) { out[0] = '-'; out[1] = '\0'; return 1; }
+    const uint8_t *p[] = { (const uint8_t *)bdaddr, (const uint8_t *)"\t", (const uint8_t *)ps, (const uint8_t *)"\t", (const uint8_t *)name, (const uint8_t *)"\t", (const uint8_t *)ip };
+    const size_t l[] = { strlen(bdaddr), 1, (size_t)pn, 1, strlen(name), 1, strlen(ip) };
+    if (!hmac_parts(g_psk, PSK_LEN, p, l, 7, mac)) { out[0] = '-'; out[1] = '\0'; return 1; }
     hexlify(mac, 16, out);
     return 32;
 }
 
 // --- HTTP request auth --------------------------------------------------------
 
-// header_hex must equal hex(HMAC(psk, "<METHOD> <path>\n" || body_sha256)).
-bool auth_check_http(const char *method, const char *path, const uint8_t body_sha[32], const char *header_hex)
+static void http_nonce(uint8_t out[HTTP_NONCE_LEN])
 {
-    if (!g_claimed || !header_hex || strlen(header_hex) != 64) return false;
+    memcpy(out, g_http_rand, 16);
+    out[16] = (uint8_t)(g_http_counter >> 24);
+    out[17] = (uint8_t)(g_http_counter >> 16);
+    out[18] = (uint8_t)(g_http_counter >> 8);
+    out[19] = (uint8_t)g_http_counter;
+}
+
+size_t auth_nonce_hex(char *out, size_t outlen)
+{
+    if (outlen < 2 * HTTP_NONCE_LEN + 1) {
+        if (outlen) out[0] = '\0';
+        return 0;
+    }
+    uint8_t n[HTTP_NONCE_LEN];
+    http_nonce(n);
+    hexlify(n, sizeof(n), out);
+    return 2 * HTTP_NONCE_LEN;
+}
+
+void auth_nonce_bump(void)
+{
+    g_http_counter++;
+}
+
+static bool check_mac(const char *header_hex, const uint8_t *const *parts, const size_t *lens, int n)
+{
+    if (!g_claimed || !header_hex || strlen(header_hex) != 2 * MAC_LEN) return false;
     uint8_t given[MAC_LEN];
     if (unhex(header_hex, MAC_LEN, given) != 0) return false;
     uint8_t mac[MAC_LEN];
-    const uint8_t *p[] = { (const uint8_t *)method, (const uint8_t *)" ", (const uint8_t *)path, (const uint8_t *)"\n", body_sha };
-    const size_t l[] = { strlen(method), 1, strlen(path), 1, 32 };
-    if (!hmac_parts(g_psk, PSK_LEN, p, l, 5, mac)) return false;
+    if (!hmac_parts(g_psk, PSK_LEN, parts, lens, n, mac)) return false;
     return auth_ct_equal(given, mac, MAC_LEN);
+}
+
+// header_hex must equal hex(HMAC(psk, "<METHOD> <path>\n" || nonce || body_sha256)).
+bool auth_check_http(const char *method, const char *path, const uint8_t body_sha[32], const char *header_hex)
+{
+    uint8_t nonce[HTTP_NONCE_LEN];
+    http_nonce(nonce);
+    const uint8_t *p[] = { (const uint8_t *)method, (const uint8_t *)" ", (const uint8_t *)path, (const uint8_t *)"\n", nonce, body_sha };
+    const size_t l[] = { strlen(method), 1, strlen(path), 1, sizeof(nonce), 32 };
+    return check_mac(header_hex, p, l, 6);
+}
+
+// header_hex must equal hex(HMAC(psk, "PRE <METHOD> <path>\n" || nonce || be32(content_len))).
+bool auth_check_http_pre(const char *method, const char *path, uint32_t content_len, const char *header_hex)
+{
+    uint8_t nonce[HTTP_NONCE_LEN];
+    http_nonce(nonce);
+    uint8_t len_be[4] = { (uint8_t)(content_len >> 24), (uint8_t)(content_len >> 16), (uint8_t)(content_len >> 8), (uint8_t)content_len };
+    const uint8_t *p[] = { (const uint8_t *)"PRE ", (const uint8_t *)method, (const uint8_t *)" ", (const uint8_t *)path, (const uint8_t *)"\n", nonce, len_be };
+    const size_t l[] = { 4, strlen(method), 1, strlen(path), 1, sizeof(nonce), 4 };
+    return check_mac(header_hex, p, l, 7);
 }
 
 // --- claim: X25519, psk = SHA256(shared) --------------------------------------

--- a/firmware/main/bridge.zig
+++ b/firmware/main/bridge.zig
@@ -13,6 +13,7 @@ const glue = struct {
     extern fn glue_poll2(a: c_int, b: c_int, timeout_ms: c_int) c_int;
     extern fn glue_recv(fd: c_int, buf: [*]u8, len: usize) c_int;
     extern fn glue_send(fd: c_int, buf: [*]const u8, len: usize) c_int;
+    extern fn glue_shutdown(fd: c_int) void;
     extern fn glue_close(fd: c_int) void;
     extern fn glue_sb_create(size: usize) ?*anyopaque;
     extern fn glue_sb_send(sb: *anyopaque, data: [*]const u8, len: usize, timeout_ms: u32) usize;
@@ -65,6 +66,9 @@ const State = struct {
     /// the new connection.
     tx_pause: std.atomic.Value(bool) = .init(false),
     tx_idle: std.atomic.Value(bool) = .init(false),
+    /// Set by the tx task on a send error. Only the rx task closes sockets,
+    /// so a tx failure is reported here and acted on from the rx loop.
+    tx_failed: std.atomic.Value(bool) = .init(false),
     sb: ?*anyopaque = null,
     send_sem: ?*anyopaque = null,
     stats: Stats = .{},
@@ -143,7 +147,9 @@ fn rxTask(_: ?*anyopaque) callconv(.c) void {
             continue;
         }
         if (ready & 1 != 0) acceptClient(&re);
-        if (ready & 2 != 0 and client >= 0) {
+        if (state.tx_failed.swap(false, .acq_rel)) dropClient("send failed");
+        // Accepting may have swapped the client, the fd polled above is then gone.
+        if (ready & 2 != 0 and client >= 0 and state.client_fd.load(.acquire) == client) {
             const n = glue.glue_recv(client, &rx_chunk, rx_chunk.len);
             if (n <= 0) {
                 dropClient("host closed connection");
@@ -183,11 +189,16 @@ fn acceptClient(re: *h4.Reassembler) void {
     const old = state.client_fd.swap(-1, .acq_rel);
     if (old >= 0) {
         log.warn("replacing existing host connection", .{});
-        glue.glue_close(old);
+        // Shutdown unblocks a pending send but keeps the fd number reserved
+        // until tx has parked, so nothing else can be handed that number.
+        glue.glue_shutdown(old);
     }
     re.reset();
+    state.tx_idle.store(false, .release);
     state.tx_pause.store(true, .release);
     while (!state.tx_idle.load(.acquire)) glue.glue_delay_ms(1);
+    if (old >= 0) glue.glue_close(old);
+    _ = state.tx_failed.swap(false, .acq_rel);
     drainStreamBuffer();
     state.client_fd.store(new_fd, .release);
     state.tx_pause.store(false, .release);
@@ -247,7 +258,8 @@ fn txTask(_: ?*anyopaque) callconv(.c) void {
             continue;
         }
         if (glue.glue_send(client, &tx_chunk, n) < 0) {
-            dropClient("send failed");
+            state.tx_failed.store(true, .release);
+            glue.glue_delay_ms(2);
         }
     }
 }

--- a/firmware/main/glue.c
+++ b/firmware/main/glue.c
@@ -124,6 +124,11 @@ int glue_send(int fd, const void *buf, size_t len)
     return (int)len;
 }
 
+void glue_shutdown(int fd)
+{
+    shutdown(fd, SHUT_RDWR);
+}
+
 void glue_close(int fd)
 {
     shutdown(fd, SHUT_RDWR);
@@ -257,6 +262,8 @@ static void bt_init(void)
 // ---------------------------------------------------------------------------
 
 #define DISCOVERY_PORT 4445
+#define ANNOUNCE_INTERVAL_MS 2000
+#define PROBE_REPLIES_PER_S 5
 
 static void discovery_task(void *arg)
 {
@@ -291,29 +298,43 @@ static void discovery_task(void *arg)
         .sin_addr.s_addr = htonl(INADDR_BROADCAST),
     };
 
-    // Non-blocking receive so one task can both broadcast and answer probes.
-    struct timeval tv = { .tv_sec = 2, .tv_usec = 0 };
+    struct timeval tv = { .tv_sec = 1, .tv_usec = 0 };
     setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
 
     ESP_LOGI(TAG, "discovery announcing on udp %d", DISCOVERY_PORT);
+    uint32_t last_announce = glue_millis() - ANNOUNCE_INTERVAL_MS;
+    uint32_t reply_window = 0;
+    int replies = 0;
     while (1) {
-        // Signed with the board key once claimed, so the host can drop spoofed announces.
-        char sig[40];
-        auth_announce_sig(bdaddr, (unsigned)CONFIG_BRIDGE_TCP_PORT, CONFIG_BRIDGE_HOSTNAME, sig, sizeof(sig));
-        alen = snprintf(announce, sizeof(announce), "ESPHCI1\tANNOUNCE\t%s\t%u\t%s\t%s\n",
-                        bdaddr, (unsigned)CONFIG_BRIDGE_TCP_PORT, CONFIG_BRIDGE_HOSTNAME, sig);
-        sendto(fd, announce, alen, 0, (struct sockaddr *)&bcast, sizeof(bcast));
+        uint32_t now = glue_millis();
+        if (now - last_announce >= ANNOUNCE_INTERVAL_MS) {
+            last_announce = now;
+            // The signature binds the board address, so nothing goes out until there is one.
+            char ip[16], sig[40];
+            alen = 0;
+            if (net_ip_str(ip, sizeof(ip))) {
+                auth_announce_sig(bdaddr, (unsigned)CONFIG_BRIDGE_TCP_PORT, CONFIG_BRIDGE_HOSTNAME, ip, sig, sizeof(sig));
+                alen = snprintf(announce, sizeof(announce), "ESPHCI1\tANNOUNCE\t%s\t%u\t%s\t%s\n",
+                                bdaddr, (unsigned)CONFIG_BRIDGE_TCP_PORT, CONFIG_BRIDGE_HOSTNAME, sig);
+                sendto(fd, announce, alen, 0, (struct sockaddr *)&bcast, sizeof(bcast));
+            }
+        }
 
-        // Drain any probes that arrived during the 2s window, reply to each.
         char buf[64];
         struct sockaddr_in from;
         socklen_t flen = sizeof(from);
         int n = recvfrom(fd, buf, sizeof(buf) - 1, 0, (struct sockaddr *)&from, &flen);
-        if (n > 0) {
-            buf[n] = 0;
-            if (strncmp(buf, "ESPHCI1\tPROBE", 13) == 0) {
-                sendto(fd, announce, alen, 0, (struct sockaddr *)&from, flen);
-            }
+        if (n <= 0 || alen == 0) continue;
+        buf[n] = 0;
+        if (strncmp(buf, "ESPHCI1\tPROBE", 13) != 0) continue;
+        now = glue_millis();
+        if (now - reply_window >= 1000) {
+            reply_window = now;
+            replies = 0;
+        }
+        if (replies < PROBE_REPLIES_PER_S) {
+            replies++;
+            sendto(fd, announce, alen, 0, (struct sockaddr *)&from, flen);
         }
     }
 }

--- a/firmware/main/glue.h
+++ b/firmware/main/glue.h
@@ -14,13 +14,17 @@ size_t bridge_stats_json(char *buf, size_t len);
 bool auth_init(void);
 bool auth_claimed(void);
 bool auth_handshake(int fd);
-size_t auth_announce_sig(const char *bdaddr, unsigned port, const char *name, char *out, size_t outlen);
+size_t auth_announce_sig(const char *bdaddr, unsigned port, const char *name, const char *ip, char *out, size_t outlen);
+size_t auth_nonce_hex(char *out, size_t outlen);
+void auth_nonce_bump(void);
 bool auth_check_http(const char *method, const char *path, const uint8_t body_sha[32], const char *header_hex);
+bool auth_check_http_pre(const char *method, const char *path, uint32_t content_len, const char *header_hex);
 bool auth_ct_equal(const uint8_t *a, const uint8_t *b, size_t n);
 int auth_claim(const uint8_t peer_pub[32], uint8_t our_pub[32]);
 
 // Implemented in net.c
 bool net_start(void);
+bool net_ip_str(char *out, size_t len);
 
 // Implemented in ota.c
 void ota_init(void);
@@ -32,6 +36,7 @@ int glue_accept(int lfd);
 int glue_poll2(int fd_a, int fd_b, int timeout_ms);
 int glue_recv(int fd, void *buf, size_t len);
 int glue_send(int fd, const void *buf, size_t len);
+void glue_shutdown(int fd);
 void glue_close(int fd);
 
 void *glue_sb_create(size_t size);

--- a/firmware/main/net.c
+++ b/firmware/main/net.c
@@ -19,12 +19,28 @@
 
 static const char *TAG = "net";
 
+static volatile uint32_t g_ip4 = 0;
+
 static void on_got_ip(void *arg, esp_event_base_t base, int32_t id, void *data)
 {
     const ip_event_got_ip_t *ev = data;
     ESP_LOGI(TAG, "ip " IPSTR " gw " IPSTR, IP2STR(&ev->ip_info.ip), IP2STR(&ev->ip_info.gw));
+    g_ip4 = ev->ip_info.ip.addr;
     // Network is up: confirm this image so rollback is cancelled and OTA is allowed.
     ota_confirm();
+}
+
+static void on_lost_ip(void *arg, esp_event_base_t base, int32_t id, void *data)
+{
+    ESP_LOGW(TAG, "ip lost");
+    g_ip4 = 0;
+}
+
+bool net_ip_str(char *out, size_t len)
+{
+    esp_ip4_addr_t a = { .addr = g_ip4 };
+    if (a.addr == 0) return false;
+    return snprintf(out, len, IPSTR, IP2STR(&a)) < (int)len;
 }
 
 // ---------------------------------------------------------------------------
@@ -86,6 +102,7 @@ static void net_start_eth(void)
     ESP_ERROR_CHECK(esp_netif_attach(netif, esp_eth_new_netif_glue(eth_handle)));
     ESP_ERROR_CHECK(esp_event_handler_register(ETH_EVENT, ESP_EVENT_ANY_ID, eth_event, NULL));
     ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_ETH_GOT_IP, on_got_ip, NULL));
+    ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_ETH_LOST_IP, on_lost_ip, NULL));
     ESP_ERROR_CHECK(esp_eth_start(eth_handle));
     ESP_LOGI(TAG, "ethernet started (MDC=%d MDIO=%d clk_gpio=%d addr=%d)",
              CONFIG_BRIDGE_ETH_MDC_GPIO, CONFIG_BRIDGE_ETH_MDIO_GPIO,
@@ -145,10 +162,13 @@ static void wifi_connect(const char *ssid, const char *pass)
     ESP_ERROR_CHECK(esp_wifi_init(&cfg));
     ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, ESP_EVENT_ANY_ID, wifi_event, NULL));
     ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP, on_got_ip, NULL));
+    ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_STA_LOST_IP, on_lost_ip, NULL));
 
+    // Neither field needs a terminator, strlcpy would cut a full-length value.
     wifi_config_t wc = {0};
-    strlcpy((char *)wc.sta.ssid, ssid, sizeof(wc.sta.ssid));
-    strlcpy((char *)wc.sta.password, pass, sizeof(wc.sta.password));
+    size_t sl = strlen(ssid), pl = strlen(pass);
+    memcpy(wc.sta.ssid, ssid, sl < sizeof(wc.sta.ssid) ? sl : sizeof(wc.sta.ssid));
+    memcpy(wc.sta.password, pass, pl < sizeof(wc.sta.password) ? pl : sizeof(wc.sta.password));
     ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
     ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wc));
     ESP_ERROR_CHECK(esp_wifi_start());

--- a/firmware/main/ota.c
+++ b/firmware/main/ota.c
@@ -15,6 +15,11 @@
 
 static const char *TAG = "ota";
 
+#define OTA_MAX_RECV_TIMEOUTS 6
+#define ROLLBACK_GRACE_US (5 * 60 * 1000000LL)
+
+static esp_timer_handle_t g_rollback_timer;
+
 static esp_err_t status_get(httpd_req_t *req)
 {
     const esp_app_desc_t *app = esp_app_get_description();
@@ -24,44 +29,56 @@ static esp_err_t status_get(httpd_req_t *req)
 
     char stats[256];
     bridge_stats_json(stats, sizeof(stats));
+    char nonce[41];
+    auth_nonce_hex(nonce, sizeof(nonce));
 
-    char body[512];
+    char body[576];
     int n = snprintf(body, sizeof(body),
                      "{\"version\":\"%s\",\"idf\":\"%s\",\"partition\":\"%s\","
-                     "\"bdaddr\":\"%02x:%02x:%02x:%02x:%02x:%02x\",\"claimed\":%s,\"uptime_s\":%lld,"
+                     "\"bdaddr\":\"%02x:%02x:%02x:%02x:%02x:%02x\",\"claimed\":%s,\"nonce\":\"%s\",\"uptime_s\":%lld,"
                      "\"free_heap\":%lu,\"stats\":%s}\n",
                      app->version, app->idf_ver, running ? running->label : "?",
                      mac[0], mac[1], mac[2], mac[3], mac[4], mac[5],
-                     auth_claimed() ? "true" : "false",
+                     auth_claimed() ? "true" : "false", nonce,
                      (long long)(esp_timer_get_time() / 1000000),
                      (unsigned long)esp_get_free_heap_size(), stats);
     httpd_resp_set_type(req, "application/json");
     return httpd_resp_send(req, body, n);
 }
 
-// Pulls the X-Bridge-Auth header (64 hex chars) or returns false.
-static bool get_auth_header(httpd_req_t *req, char *out, size_t outlen)
+static bool get_header(httpd_req_t *req, const char *name, char *out, size_t outlen)
 {
-    size_t n = httpd_req_get_hdr_value_len(req, "X-Bridge-Auth");
+    size_t n = httpd_req_get_hdr_value_len(req, name);
     if (n == 0 || n + 1 > outlen) return false;
-    return httpd_req_get_hdr_value_str(req, "X-Bridge-Auth", out, outlen) == ESP_OK;
+    return httpd_req_get_hdr_value_str(req, name, out, outlen) == ESP_OK;
+}
+
+// Both proofs are bound to the nonce published by GET /, so each is only
+// good for one accepted request.
+static bool get_proofs(httpd_req_t *req, char *auth, char *pre, size_t len)
+{
+    return auth_claimed() && get_header(req, "X-Bridge-Auth", auth, len) && get_header(req, "X-Bridge-Pre", pre, len);
 }
 
 static esp_err_t ota_post(httpd_req_t *req)
 {
-    // The body is hashed while it streams to flash; the proof is checked
-    // before the new slot is ever selected for boot.
-    char hdr[80];
-    if (!auth_claimed() || !get_auth_header(req, hdr, sizeof(hdr))) {
-        httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "X-Bridge-Auth required (claim the board first)");
+    char auth[80], pre[80];
+    if (!get_proofs(req, auth, pre, sizeof(auth))) {
+        httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "X-Bridge-Auth and X-Bridge-Pre required (claim the board first)");
         return ESP_FAIL;
     }
-    mbedtls_sha256_context sha;
-    mbedtls_sha256_init(&sha);
-    mbedtls_sha256_starts(&sha, 0);
     const esp_partition_t *part = esp_ota_get_next_update_partition(NULL);
     if (!part) {
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "no ota partition");
+        return ESP_FAIL;
+    }
+    if (req->content_len > part->size) {
+        httpd_resp_send_err(req, HTTPD_413_CONTENT_TOO_LARGE, "image larger than the ota partition");
+        return ESP_FAIL;
+    }
+    if (!auth_check_http_pre("POST", "/ota", (uint32_t)req->content_len, pre)) {
+        ESP_LOGW(TAG, "rejected OTA: bad pre-upload proof");
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "bad X-Bridge-Pre");
         return ESP_FAIL;
     }
     ESP_LOGI(TAG, "update of %d bytes into %s", req->content_len, part->label);
@@ -73,12 +90,20 @@ static esp_err_t ota_post(httpd_req_t *req)
         return ESP_FAIL;
     }
 
+    mbedtls_sha256_context sha;
+    mbedtls_sha256_init(&sha);
+    mbedtls_sha256_starts(&sha, 0);
     char buf[1024];
     int remaining = req->content_len;
+    int timeouts = 0;
     while (remaining > 0) {
         int n = httpd_req_recv(req, buf, remaining < (int)sizeof(buf) ? remaining : (int)sizeof(buf));
         if (n == HTTPD_SOCK_ERR_TIMEOUT) {
-            continue;
+            if (++timeouts < OTA_MAX_RECV_TIMEOUTS) continue;
+            esp_ota_abort(handle);
+            mbedtls_sha256_free(&sha);
+            httpd_resp_send_err(req, HTTPD_408_REQ_TIMEOUT, "upload stalled");
+            return ESP_FAIL;
         }
         if (n <= 0) {
             esp_ota_abort(handle);
@@ -86,6 +111,7 @@ static esp_err_t ota_post(httpd_req_t *req)
             httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "upload interrupted");
             return ESP_FAIL;
         }
+        timeouts = 0;
         mbedtls_sha256_update(&sha, (const unsigned char *)buf, n);
         err = esp_ota_write(handle, buf, n);
         if (err != ESP_OK) {
@@ -100,7 +126,7 @@ static esp_err_t ota_post(httpd_req_t *req)
     uint8_t digest[32];
     mbedtls_sha256_finish(&sha, digest);
     mbedtls_sha256_free(&sha);
-    if (!auth_check_http("POST", "/ota", digest, hdr)) {
+    if (!auth_check_http("POST", "/ota", digest, auth)) {
         esp_ota_abort(handle);
         ESP_LOGW(TAG, "rejected OTA: bad auth");
         httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "bad X-Bridge-Auth");
@@ -117,6 +143,7 @@ static esp_err_t ota_post(httpd_req_t *req)
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, esp_err_to_name(err));
         return ESP_FAIL;
     }
+    auth_nonce_bump();
 
     httpd_resp_sendstr(req, "ok, rebooting\n");
     ESP_LOGI(TAG, "update written, rebooting");
@@ -127,13 +154,15 @@ static esp_err_t ota_post(httpd_req_t *req)
 
 static esp_err_t reboot_post(httpd_req_t *req)
 {
-    char hdr[80];
+    char auth[80], pre[80];
     uint8_t empty_sha[32];
     mbedtls_sha256((const unsigned char *)"", 0, empty_sha, 0);
-    if (!auth_claimed() || !get_auth_header(req, hdr, sizeof(hdr)) || !auth_check_http("POST", "/reboot", empty_sha, hdr)) {
-        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "bad or missing X-Bridge-Auth");
+    if (!get_proofs(req, auth, pre, sizeof(auth)) || !auth_check_http_pre("POST", "/reboot", 0, pre) ||
+        !auth_check_http("POST", "/reboot", empty_sha, auth)) {
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "bad or missing X-Bridge-Auth / X-Bridge-Pre");
         return ESP_FAIL;
     }
+    auth_nonce_bump();
     httpd_resp_sendstr(req, "rebooting\n");
     ESP_LOGI(TAG, "reboot requested");
     vTaskDelay(pdMS_TO_TICKS(300));
@@ -176,8 +205,30 @@ static esp_err_t claim_post(httpd_req_t *req)
     return httpd_resp_send(req, out, 65);
 }
 
+static bool pending_verify(void)
+{
+    esp_ota_img_states_t state;
+    const esp_partition_t *running = esp_ota_get_running_partition();
+    return esp_ota_get_state_partition(running, &state) == ESP_OK && state == ESP_OTA_IMG_PENDING_VERIFY;
+}
+
+// A fresh image that never gets an address would otherwise stay unconfirmed
+// forever, the reboot lets the bootloader roll back.
+static void rollback_timeout(void *arg)
+{
+    if (!pending_verify()) return;
+    ESP_LOGE(TAG, "no ip within the grace period, rebooting to roll back");
+    esp_restart();
+}
+
 void ota_init(void)
 {
+    if (pending_verify()) {
+        const esp_timer_create_args_t args = { .callback = rollback_timeout, .name = "ota_rollback" };
+        ESP_ERROR_CHECK(esp_timer_create(&args, &g_rollback_timer));
+        ESP_ERROR_CHECK(esp_timer_start_once(g_rollback_timer, ROLLBACK_GRACE_US));
+    }
+
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.stack_size = 8192;
     config.lru_purge_enable = true;
@@ -200,10 +251,9 @@ void ota_init(void)
 // address. Otherwise the bootloader rolls back on the next reset.
 void ota_confirm(void)
 {
-    esp_ota_img_states_t state;
-    const esp_partition_t *running = esp_ota_get_running_partition();
-    if (esp_ota_get_state_partition(running, &state) == ESP_OK && state == ESP_OTA_IMG_PENDING_VERIFY) {
+    if (pending_verify()) {
         esp_ota_mark_app_valid_cancel_rollback();
         ESP_LOGI(TAG, "image confirmed");
     }
+    if (g_rollback_timer) esp_timer_stop(g_rollback_timer);
 }

--- a/host/board.zig
+++ b/host/board.zig
@@ -9,19 +9,45 @@ const handshake = @import("handshake.zig");
 
 const log = std.log.scoped(.board);
 
+/// Lets the manager tear down a live link when the board reappears from a new address.
+pub const Link = struct {
+    mutex: Io.Mutex = .init,
+    stream: ?Io.net.Stream = null,
+
+    pub fn kill(self: *Link, io: Io) void {
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
+        if (self.stream) |s| s.shutdown(io, .both) catch {};
+    }
+
+    fn set(self: *Link, io: Io, stream: ?Io.net.Stream) void {
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
+        self.stream = stream;
+    }
+};
+
 /// Runs one authenticated connection. Returns when the link drops. Never
 /// loops; the caller retries (static mode) or waits for rediscovery.
-pub fn run(io: Io, addr: *const Io.net.IpAddress, vhci_path: []const u8, label: []const u8, psk: *const auth.Psk) !session.Stats {
+pub fn run(io: Io, addr: *const Io.net.IpAddress, vhci_path: []const u8, label: []const u8, psk: *const auth.Psk, link: ?*Link) !session.Stats {
     var stream = try addr.connect(io, .{ .mode = .stream });
     defer stream.close(io);
     try session.tuneSocket(stream.socket.handle);
     log.info("[{s}] connected to {f}, authenticating", .{ label, addr.* });
 
-    handshake.client(io, stream, psk) catch |err| {
-        log.err("[{s}] authentication failed: {s} (wrong key, or not the real board)", .{ label, @errorName(err) });
-        return error.AuthFailed;
+    handshake.client(io, stream, psk) catch |err| switch (err) {
+        error.HandshakeTimeout => {
+            log.warn("[{s}] board did not answer the handshake in time", .{label});
+            return error.HandshakeTimeout;
+        },
+        else => {
+            log.err("[{s}] authentication failed: {s} (wrong key, or not the real board)", .{ label, @errorName(err) });
+            return error.AuthFailed;
+        },
     };
     log.info("[{s}] authenticated", .{label});
+    if (link) |l| l.set(io, stream);
+    defer if (link) |l| l.set(io, null);
 
     // The kernel only sees this peer after it proved it holds the key.
     const vhci = Io.Dir.openFileAbsolute(io, vhci_path, .{ .mode = .read_write }) catch |err| {

--- a/host/cli.zig
+++ b/host/cli.zig
@@ -18,14 +18,24 @@ fn loadKeys(io: Io, gpa: std.mem.Allocator, cfg_path: []const u8) !settings.Sett
     return settings.resolve(gpa, raw.pairs.items, &.{}, null, null);
 }
 
-fn boardInfo(io: Io, gpa: std.mem.Allocator, addr: *const Io.net.IpAddress, bdaddr_out: *[17]u8) !struct { bdaddr: []const u8, claimed: ?bool } {
+const BoardInfo = struct {
+    bdaddr: []const u8,
+    /// null: firmware before v0.10 (no key support at all)
+    claimed: ?bool,
+    /// null: firmware before v0.10.3 (replayable proofs, see auth.httpAuthLegacy)
+    nonce: ?auth.HttpNonce,
+};
+
+fn boardInfo(io: Io, gpa: std.mem.Allocator, addr: *const Io.net.IpAddress, bdaddr_out: *[17]u8) !BoardInfo {
     var r = try httpc.get(io, gpa, addr, "/");
     defer r.deinit(gpa);
-    var buf: [32]u8 = undefined;
+    var buf: [48]u8 = undefined;
     const b = httpc.jsonField(r.body, "bdaddr", &buf) orelse return error.NoBdaddr;
     if (b.len != 17) return error.NoBdaddr;
     @memcpy(bdaddr_out, b);
-    return .{ .bdaddr = bdaddr_out, .claimed = httpc.jsonBool(r.body, "claimed") };
+    var nbuf: [48]u8 = undefined;
+    const nonce = if (httpc.jsonField(r.body, "nonce", &nbuf)) |h| auth.hexToNonce(h) else null;
+    return .{ .bdaddr = bdaddr_out, .claimed = httpc.jsonBool(r.body, "claimed"), .nonce = nonce };
 }
 
 const log = std.log;
@@ -161,9 +171,17 @@ fn readFile(io: Io, gpa: std.mem.Allocator, path: []const u8) ![]u8 {
     return out.toOwnedSlice(gpa);
 }
 
-fn authHeader(psk: *const auth.Psk, method: []const u8, path: []const u8, body: []const u8, out: *[80]u8) []const u8 {
+/// Both proof headers on one line pair, or the legacy single header for
+/// boards that publish no nonce.
+fn authHeaders(psk: *const auth.Psk, method: []const u8, path: []const u8, nonce: ?auth.HttpNonce, body: []const u8, out: *[160]u8) []const u8 {
     var mac: [auth.mac_len * 2]u8 = undefined;
-    _ = auth.httpAuth(psk, method, path, body, &mac);
+    if (nonce) |n| {
+        var pre: [auth.mac_len * 2]u8 = undefined;
+        _ = auth.httpAuth(psk, method, path, &n, body, &mac);
+        _ = auth.httpPre(psk, method, path, &n, @intCast(body.len), &pre);
+        return std.fmt.bufPrint(out, "X-Bridge-Auth: {s}\r\nX-Bridge-Pre: {s}", .{ &mac, &pre }) catch unreachable;
+    }
+    _ = auth.httpAuthLegacy(psk, method, path, body, &mac);
     return std.fmt.bufPrint(out, "X-Bridge-Auth: {s}", .{&mac}) catch unreachable;
 }
 
@@ -175,14 +193,14 @@ fn updateOne(io: Io, gpa: std.mem.Allocator, addr: *const Io.net.IpAddress, imag
     };
     // Firmware before v0.10 reports no claim state and takes unauthenticated
     // uploads, which is the only way to move such a board onto keyed firmware.
-    var hbuf: [80]u8 = undefined;
+    var hbuf: [160]u8 = undefined;
     var hdr: ?[]const u8 = null;
     if (info.claimed != null) {
         const psk = settings.lookupPsk(keys.psk, info.bdaddr) orelse {
             log.err("no key for {s} ({f}): run `hcibridge claim` first", .{ info.bdaddr, addr.* });
             return false;
         };
-        hdr = authHeader(&psk, "POST", "/ota", image, &hbuf);
+        hdr = authHeaders(&psk, "POST", "/ota", info.nonce, image, &hbuf);
     } else log.warn("{f} runs pre-key firmware, sending unauthenticated update", .{addr.*});
     log.info("updating {f} ({s}), {d} bytes", .{ addr.*, info.bdaddr, image.len });
     var r = httpc.postH(io, gpa, addr, "/ota", image, hdr) catch |err| {
@@ -244,8 +262,8 @@ pub fn reboot(io: Io, gpa: std.mem.Allocator, ip: []const u8, cfg_path: []const 
         log.err("no key for {s}: run `hcibridge claim {s}` first", .{ info.bdaddr, ip });
         return 1;
     };
-    var hbuf: [80]u8 = undefined;
-    const hdr = authHeader(&psk, "POST", "/reboot", "", &hbuf);
+    var hbuf: [160]u8 = undefined;
+    const hdr = authHeaders(&psk, "POST", "/reboot", info.nonce, "", &hbuf);
     var r = try httpc.postH(io, gpa, &addr, "/reboot", "", hdr);
     defer r.deinit(gpa);
     if (r.status != 200) {

--- a/host/cli.zig
+++ b/host/cli.zig
@@ -11,11 +11,22 @@ const X25519 = std.crypto.dh.X25519;
 
 pub const default_config = "/etc/hcibridge/config";
 
-/// Loads psk entries from the config (main + .d). Caller deinit()s.
+fn envGet(ctx: ?*anyopaque, name: []const u8) ?[]const u8 {
+    const env: *const std.process.Environ = @ptrCast(@alignCast(ctx.?));
+    return env.getPosix(name);
+}
+
+/// Loads psk entries from the config (main + .d) and HCIBRIDGE_PSK. Caller deinit()s.
 fn loadKeys(io: Io, gpa: std.mem.Allocator, cfg_path: []const u8) !settings.Settings {
-    var raw = config.loadRaw(gpa, io, cfg_path) catch config.Raw{ .arena = std.heap.ArenaAllocator.init(gpa) };
+    var raw = config.loadRaw(gpa, io, cfg_path) catch |err| blk: {
+        log.warn("config {s}: {s} (using defaults)", .{ cfg_path, @errorName(err) });
+        break :blk config.Raw{ .arena = std.heap.ArenaAllocator.init(gpa) };
+    };
     defer raw.deinit();
-    return settings.resolve(gpa, raw.pairs.items, &.{}, null, null);
+    // The process Io is always Io.Threaded (see start.zig), which carries the environ.
+    const threaded: *Io.Threaded = @ptrCast(@alignCast(io.userdata));
+    var env = threaded.environ.process_environ;
+    return settings.resolve(gpa, raw.pairs.items, &.{}, envGet, @ptrCast(&env));
 }
 
 const BoardInfo = struct {
@@ -69,16 +80,9 @@ pub fn collect(io: Io, gpa: std.mem.Allocator, discovery_port: u16, window_ms: u
     sock.send(io, &bcast, disc.buildProbe(&pbuf)) catch {};
 
     var rbuf: [disc.max_datagram]u8 = undefined;
-    const tick_ms: u32 = 250;
-    var ticks = @max(@as(u32, 1), window_ms / tick_ms);
-    while (ticks > 0) {
-        const msg = sock.receiveTimeout(io, &rbuf, .{ .duration = .{ .raw = Io.Duration.fromMilliseconds(tick_ms), .clock = .awake } }) catch |err| switch (err) {
-            error.Timeout => {
-                ticks -= 1;
-                continue;
-            },
-            else => break,
-        };
+    const deadline = Io.Clock.Timestamp.fromNow(io, .{ .raw = Io.Duration.fromMilliseconds(window_ms), .clock = .awake });
+    while (deadline.durationFromNow(io).raw.nanoseconds > 0) {
+        const msg = sock.receiveTimeout(io, &rbuf, .{ .deadline = deadline }) catch break;
         const parsed = disc.parse(msg.data) catch continue;
         const ann = switch (parsed) {
             .announce => |a| a,
@@ -303,6 +307,10 @@ pub fn claim(io: Io, gpa: std.mem.Allocator, ip: []const u8, cfg_path: []const u
     }
     const board_hex = std.mem.trim(u8, r.body, " \r\n");
     var board_pk: [32]u8 = undefined;
+    if (board_hex.len != board_pk.len * 2) {
+        log.err("bad board public key in reply: {d} chars, want 64", .{board_hex.len});
+        return 1;
+    }
     _ = std.fmt.hexToBytes(&board_pk, board_hex) catch {
         log.err("bad board public key in reply", .{});
         return 1;
@@ -327,12 +335,16 @@ pub fn claim(io: Io, gpa: std.mem.Allocator, ip: []const u8, cfg_path: []const u
         var out = Io.File.stdout().writer(io, &obuf);
         try out.interface.print("# add this line to {s} (or a .d drop-in):\n{s}", .{ cfg_path, line });
         try out.interface.flush();
+        return 3;
     }
     return 0;
 }
 
+/// Writes a secret: created 0600, and re-chmodded in case the file already existed.
 fn writeFile(io: Io, path: []const u8, data: []const u8) !void {
-    const f = try Io.Dir.cwd().createFile(io, path, .{ .truncate = true });
+    const mode: Io.File.Permissions = .fromMode(0o600);
+    const f = try Io.Dir.cwd().createFile(io, path, .{ .truncate = true, .permissions = mode });
     defer f.close(io);
+    try f.setPermissions(io, mode);
     try f.writeStreamingAll(io, data);
 }

--- a/host/config.zig
+++ b/host/config.zig
@@ -3,14 +3,20 @@
 //! Returns raw `key = value` pairs in order; typing and precedence live in
 //! settings.zig so this stays a dumb, testable reader.
 //!
-//! Format: `key = value`, `#` or `;` comments, blank lines ignored.
+//! Format: `key = value`, `#` or `;` comments (also after a value), blank
+//! lines ignored.
 
 const std = @import("std");
 const Io = std.Io;
 
 const log = std.log.scoped(.config);
 
-pub const Pair = struct { key: []const u8, value: []const u8 };
+pub const Pair = struct {
+    key: []const u8,
+    value: []const u8,
+    /// File the pair came from, for diagnostics.
+    source: []const u8 = "config",
+};
 
 pub const Raw = struct {
     arena: std.heap.ArenaAllocator,
@@ -21,13 +27,18 @@ pub const Raw = struct {
     }
 
     pub fn applyText(self: *Raw, text: []const u8) !void {
+        return self.applyTextFrom(text, "config");
+    }
+
+    pub fn applyTextFrom(self: *Raw, text: []const u8, source: []const u8) !void {
         const alloc = self.arena.allocator();
+        const src = try alloc.dupe(u8, source);
         var lines = std.mem.splitScalar(u8, text, '\n');
         while (lines.next()) |raw| {
-            const line = std.mem.trim(u8, raw, " \t\r");
-            if (line.len == 0 or line[0] == '#' or line[0] == ';') continue;
+            const line = std.mem.trim(u8, stripComment(raw), " \t\r");
+            if (line.len == 0) continue;
             const eq = std.mem.indexOfScalar(u8, line, '=') orelse {
-                log.warn("ignoring line without '=': {s}", .{line});
+                log.warn("{s}: ignoring line without '=': {s}", .{ source, line });
                 continue;
             };
             const key = std.mem.trim(u8, line[0..eq], " \t");
@@ -36,10 +47,20 @@ pub const Raw = struct {
             try self.pairs.append(alloc, .{
                 .key = try alloc.dupe(u8, key),
                 .value = try alloc.dupe(u8, val),
+                .source = src,
             });
         }
     }
 };
+
+/// A `#` or `;` at the start of the line or after whitespace begins a comment.
+fn stripComment(line: []const u8) []const u8 {
+    for (line, 0..) |c, i| {
+        if (c != '#' and c != ';') continue;
+        if (i == 0 or line[i - 1] == ' ' or line[i - 1] == '\t') return line[0..i];
+    }
+    return line;
+}
 
 fn readFile(io: Io, gpa: std.mem.Allocator, path: []const u8) !?[]u8 {
     const f = Io.Dir.cwd().openFile(io, path, .{ .mode = .read_only }) catch |err| switch (err) {
@@ -61,14 +82,15 @@ fn readFile(io: Io, gpa: std.mem.Allocator, path: []const u8) !?[]u8 {
     return try out.toOwnedSlice(gpa);
 }
 
-/// Reads `path` then `<path>.d/*.conf` (sorted). Missing files are fine.
+/// Reads `path` then `<path>.d/*.conf` (sorted). Missing files are fine, an
+/// unreadable drop-in is skipped with a warning.
 pub fn loadRaw(gpa: std.mem.Allocator, io: Io, path: []const u8) !Raw {
     var raw: Raw = .{ .arena = std.heap.ArenaAllocator.init(gpa) };
     errdefer raw.deinit();
 
     if (try readFile(io, gpa, path)) |main| {
         defer gpa.free(main);
-        try raw.applyText(main);
+        try raw.applyTextFrom(main, path);
     }
 
     var dbuf: [512]u8 = undefined;
@@ -87,7 +109,10 @@ pub fn loadRaw(gpa: std.mem.Allocator, io: Io, path: []const u8) !Raw {
     }
     var it = dir.iterate();
     while (try it.next(io)) |entry| {
-        if (entry.kind != .file) continue;
+        switch (entry.kind) {
+            .file, .sym_link, .unknown => {},
+            else => continue,
+        }
         if (!std.mem.endsWith(u8, entry.name, ".conf")) continue;
         try names.append(gpa, try gpa.dupe(u8, entry.name));
     }
@@ -100,10 +125,15 @@ pub fn loadRaw(gpa: std.mem.Allocator, io: Io, path: []const u8) !Raw {
     for (names.items) |name| {
         var fbuf: [640]u8 = undefined;
         const fpath = std.fmt.bufPrint(&fbuf, "{s}/{s}", .{ dpath, name }) catch continue;
-        if (try readFile(io, gpa, fpath)) |frag| {
-            defer gpa.free(frag);
-            raw.applyText(frag) catch |err| log.warn("{s}: {s}", .{ name, @errorName(err) });
-        }
+        const frag = readFile(io, gpa, fpath) catch |err| {
+            log.warn("{s}: {s}, skipping", .{ fpath, @errorName(err) });
+            continue;
+        } orelse {
+            log.warn("{s}: not found, skipping", .{fpath});
+            continue;
+        };
+        defer gpa.free(frag);
+        raw.applyTextFrom(frag, fpath) catch |err| log.warn("{s}: {s}", .{ fpath, @errorName(err) });
     }
     return raw;
 }
@@ -117,4 +147,40 @@ test "pairs preserve order and repetition" {
     try testing.expectEqual(@as(usize, 3), r.pairs.items.len);
     try testing.expectEqualStrings("a", r.pairs.items[0].key);
     try testing.expectEqualStrings("3", r.pairs.items[2].value);
+}
+
+test "inline comments after a value are stripped" {
+    var r: Raw = .{ .arena = std.heap.ArenaAllocator.init(testing.allocator) };
+    defer r.deinit();
+    try r.applyText("port = 4444  # x\nvhci = /dev/vhci ; y\nname = a#b\n");
+    try testing.expectEqual(@as(usize, 3), r.pairs.items.len);
+    try testing.expectEqualStrings("4444", r.pairs.items[0].value);
+    try testing.expectEqualStrings("/dev/vhci", r.pairs.items[1].value);
+    try testing.expectEqualStrings("a#b", r.pairs.items[2].value);
+}
+
+test "drop-ins include regular files and symlinks, unreadable ones are skipped" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "config.d");
+    try tmp.dir.writeFile(io, .{ .sub_path = "config", .data = "a = main\n" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "config.d/10-a.conf", .data = "a = 1\n" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "target.txt", .data = "b = 2\n" });
+    try tmp.dir.symLink(io, "../target.txt", "config.d/20-b.conf", .{});
+    try tmp.dir.symLink(io, "missing.txt", "config.d/30-dangling.conf", .{});
+
+    var pbuf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPath(io, &pbuf);
+    var cbuf: [std.fs.max_path_bytes]u8 = undefined;
+    const cfg = try std.fmt.bufPrint(&cbuf, "{s}/config", .{pbuf[0..n]});
+
+    var r = try loadRaw(testing.allocator, io, cfg);
+    defer r.deinit();
+    try testing.expectEqual(@as(usize, 3), r.pairs.items.len);
+    try testing.expectEqualStrings("main", r.pairs.items[0].value);
+    try testing.expectEqualStrings("1", r.pairs.items[1].value);
+    try testing.expectEqualStrings("b", r.pairs.items[2].key);
+    try testing.expectEqualStrings("2", r.pairs.items[2].value);
+    try testing.expect(std.mem.endsWith(u8, r.pairs.items[2].source, "20-b.conf"));
 }

--- a/host/config/config
+++ b/host/config/config
@@ -6,7 +6,8 @@
 # Drop-in fragments in /etc/hcibridge/config.d/*.conf are merged on top of this
 # file, sorted by name. Scalars are last-wins, lists (client/allow/deny/psk) add up.
 #
-# Format: key = value   ('#' or ';' begins a comment)
+# Format: key = value   ('#' or ';' begins a comment, also after a value)
+# Unknown keys and values that do not parse are logged and ignored.
 
 # Auto-discover boards on the LAN.            env HCIBRIDGE_DISCOVERY
 # discovery = on
@@ -40,6 +41,7 @@
 # deny = aa:bb:cc:dd:ee:ff
 
 # Board keys. 'hcibridge claim <ip>' pairs a board with this PC and writes one
-# of these to config.d/board-<bdaddr>.conf. A board without a key here is
-# never attached. env HCIBRIDGE_PSK (comma-separated)
+# of these to config.d/board-<bdaddr>.conf (mode 0600). A board without a key
+# here is never attached. The last entry for a board wins.
+# env HCIBRIDGE_PSK (comma-separated)
 # psk = a0:a3:b3:2f:61:1e=0123...cdef

--- a/host/config/config.d/50-example.conf
+++ b/host/config/config.d/50-example.conf
@@ -1,3 +1,4 @@
 # Example drop-in. Copy to e.g. 10-livingroom.conf and uncomment.
-# Later files (higher numbers) override earlier ones for scalar keys.
+# Later files (higher numbers) override earlier ones for scalar keys and for
+# the psk of a given board. Symlinked *.conf files are read too.
 # allow = a0:a3:b3:2f:61:1e

--- a/host/handshake.zig
+++ b/host/handshake.zig
@@ -7,21 +7,50 @@
 
 const std = @import("std");
 const Io = std.Io;
+const posix = std.posix;
 const auth = @import("auth");
 
-pub const Error = error{AuthFailed} || anyerror;
+pub const Error = error{ AuthFailed, HandshakeTimeout } || anyerror;
+
+pub const default_timeout: Io.Duration = .fromMilliseconds(5000);
+
+pub const Options = struct {
+    /// Bound on the whole exchange, so a silent peer cannot park a session.
+    timeout: Io.Duration = default_timeout,
+    /// Board side test hook: sign the reply with this key instead of `psk`.
+    reply_psk: ?*const auth.Psk = null,
+};
 
 fn randomNonce(io: Io, out: *auth.Nonce) void {
     io.randomSecure(out) catch io.random(out);
 }
 
+fn readAllBy(io: Io, fd: posix.fd_t, buf: []u8, deadline: Io.Clock.Timestamp) !void {
+    var got: usize = 0;
+    while (got < buf.len) {
+        const left = deadline.durationFromNow(io).raw.toMilliseconds();
+        if (left <= 0) return error.HandshakeTimeout;
+        var fds = [_]posix.pollfd{.{ .fd = fd, .events = posix.POLL.IN, .revents = 0 }};
+        const ready = try posix.poll(&fds, @intCast(@min(left, std.math.maxInt(i32))));
+        if (ready == 0) return error.HandshakeTimeout;
+        const n = try posix.read(fd, buf[got..]);
+        if (n == 0) return error.EndOfStream;
+        got += n;
+    }
+}
+
 /// Client (PC) side. Returns error.AuthFailed if the board's proof is wrong.
 pub fn client(io: Io, stream: Io.net.Stream, psk: *const auth.Psk) !void {
-    var r = stream.reader(io, &.{});
+    return clientWith(io, stream, psk, .{});
+}
+
+pub fn clientWith(io: Io, stream: Io.net.Stream, psk: *const auth.Psk, opts: Options) !void {
+    const deadline = Io.Clock.Timestamp.fromNow(io, .{ .raw = opts.timeout, .clock = .awake });
+    const fd = stream.socket.handle;
     var w = stream.writer(io, &.{});
 
     var server_nonce: auth.Nonce = undefined;
-    try r.interface.readSliceAll(&server_nonce);
+    try readAllBy(io, fd, &server_nonce, deadline);
 
     var client_nonce: auth.Nonce = undefined;
     randomNonce(io, &client_nonce);
@@ -31,14 +60,19 @@ pub fn client(io: Io, stream: Io.net.Stream, psk: *const auth.Psk) !void {
     try w.interface.flush();
 
     var bmac: auth.Mac = undefined;
-    try r.interface.readSliceAll(&bmac);
+    try readAllBy(io, fd, &bmac, deadline);
     const expect = auth.boardMac(psk, &client_nonce, &server_nonce);
     if (!auth.ctEqual(&bmac, &expect)) return error.AuthFailed;
 }
 
 /// Board side (used by the simulator; the firmware implements the same in C).
 pub fn board(io: Io, stream: Io.net.Stream, psk: *const auth.Psk) !void {
-    var r = stream.reader(io, &.{});
+    return boardWith(io, stream, psk, .{});
+}
+
+pub fn boardWith(io: Io, stream: Io.net.Stream, psk: *const auth.Psk, opts: Options) !void {
+    const deadline = Io.Clock.Timestamp.fromNow(io, .{ .raw = opts.timeout, .clock = .awake });
+    const fd = stream.socket.handle;
     var w = stream.writer(io, &.{});
 
     var server_nonce: auth.Nonce = undefined;
@@ -47,13 +81,13 @@ pub fn board(io: Io, stream: Io.net.Stream, psk: *const auth.Psk) !void {
     try w.interface.flush();
 
     var msg: [auth.nonce_len + auth.mac_len]u8 = undefined;
-    try r.interface.readSliceAll(&msg);
+    try readAllBy(io, fd, &msg, deadline);
     const client_nonce: *const auth.Nonce = msg[0..auth.nonce_len];
     const cmac = msg[auth.nonce_len..];
     const expect = auth.clientMac(psk, &server_nonce, client_nonce);
     if (!auth.ctEqual(cmac, &expect)) return error.AuthFailed;
 
-    const bmac = auth.boardMac(psk, client_nonce, &server_nonce);
+    const bmac = auth.boardMac(opts.reply_psk orelse psk, client_nonce, &server_nonce);
     try w.interface.writeAll(&bmac);
     try w.interface.flush();
 }

--- a/host/httpc.zig
+++ b/host/httpc.zig
@@ -6,6 +6,8 @@ const std = @import("std");
 const Io = std.Io;
 
 pub const http_port: u16 = 80;
+/// Largest response accepted, header and body together.
+pub const max_body: usize = 1 << 20;
 
 pub const Response = struct {
     status: u16,
@@ -16,15 +18,41 @@ pub const Response = struct {
     }
 };
 
-fn contentLength(head: []const u8) ?usize {
+fn contentLength(head: []const u8) ?u64 {
     var lines = std.mem.splitSequence(u8, head, "\r\n");
     while (lines.next()) |line| {
         const colon = std.mem.indexOfScalar(u8, line, ':') orelse continue;
         if (std.ascii.eqlIgnoreCase(std.mem.trim(u8, line[0..colon], " "), "content-length")) {
-            return std.fmt.parseInt(usize, std.mem.trim(u8, line[colon + 1 ..], " "), 10) catch null;
+            return std.fmt.parseInt(u64, std.mem.trim(u8, line[colon + 1 ..], " "), 10) catch null;
         }
     }
     return null;
+}
+
+/// Total bytes to expect once the header is in, null while the header is
+/// incomplete or carries no Content-Length.
+fn expectedLen(buf: []const u8) error{ResponseTooLarge}!?usize {
+    const sep = std.mem.indexOf(u8, buf, "\r\n\r\n") orelse return null;
+    const cl = contentLength(buf[0..sep]) orelse return null;
+    if (cl > max_body) return error.ResponseTooLarge;
+    return std.math.add(usize, sep + 4, @intCast(cl)) catch error.ResponseTooLarge;
+}
+
+fn parseResponse(gpa: std.mem.Allocator, bytes: []const u8) !Response {
+    const sep = std.mem.indexOf(u8, bytes, "\r\n\r\n") orelse return error.BadResponse;
+    const head = bytes[0..sep];
+    var body = bytes[sep + 4 ..];
+    if (contentLength(head)) |cl| {
+        if (cl < body.len) body = body[0..@intCast(cl)];
+    }
+
+    var lines = std.mem.splitSequence(u8, head, "\r\n");
+    const status_line = lines.next() orelse return error.BadResponse;
+    var parts = std.mem.tokenizeScalar(u8, status_line, ' ');
+    _ = parts.next() orelse return error.BadResponse;
+    const code_s = parts.next() orelse return error.BadResponse;
+    const status = std.fmt.parseInt(u16, code_s, 10) catch return error.BadResponse;
+    return .{ .status = status, .body = try gpa.dupe(u8, body) };
 }
 
 /// Reads a full HTTP response. Honors Content-Length so it does not hang on a
@@ -34,41 +62,24 @@ fn readResponse(io: Io, stream: Io.net.Stream, gpa: std.mem.Allocator) !Response
     defer buf.deinit(gpa);
     var rbuf: [4096]u8 = undefined;
     var reader = stream.reader(io, &rbuf);
-
     const r = &reader.interface;
-    var header_end: ?usize = null;
-    var want: ?usize = null; // total bytes = header_end + 4 + content-length
 
     while (true) {
-        if (header_end == null) {
-            if (std.mem.indexOf(u8, buf.items, "\r\n\r\n")) |sep| {
-                header_end = sep;
-                if (contentLength(buf.items[0..sep])) |cl| want = sep + 4 + cl;
-            }
-        }
-        if (want) |w| if (buf.items.len >= w) break;
+        if (try expectedLen(buf.items)) |want| {
+            if (buf.items.len >= want) break;
+        } else if (buf.items.len > max_body) return error.ResponseTooLarge;
 
-        // Block for at least one byte, then drain whatever is buffered. This
-        // returns as data arrives instead of waiting to fill a fixed buffer.
-        r.fill(1) catch break; // EndOfStream ends the read
+        // fill(1) returns as soon as anything arrives instead of filling the buffer.
+        r.fill(1) catch |err| switch (err) {
+            error.EndOfStream => break,
+            else => return err,
+        };
         const avail = r.buffered();
         if (avail.len == 0) break;
         try buf.appendSlice(gpa, avail);
         r.tossBuffered();
     }
-
-    const sep = header_end orelse return error.BadResponse;
-    const head = buf.items[0..sep];
-    const body_all = buf.items[sep + 4 ..];
-    const body = if (want) |w| buf.items[sep + 4 .. @min(w, buf.items.len)] else body_all;
-
-    var lines = std.mem.splitSequence(u8, head, "\r\n");
-    const status_line = lines.next() orelse return error.BadResponse;
-    var parts = std.mem.tokenizeScalar(u8, status_line, ' ');
-    _ = parts.next() orelse return error.BadResponse;
-    const code_s = parts.next() orelse return error.BadResponse;
-    const status = std.fmt.parseInt(u16, code_s, 10) catch return error.BadResponse;
-    return .{ .status = status, .body = try gpa.dupe(u8, body) };
+    return parseResponse(gpa, buf.items);
 }
 
 pub fn get(io: Io, gpa: std.mem.Allocator, addr: *const Io.net.IpAddress, path: []const u8) !Response {
@@ -132,8 +143,33 @@ pub fn jsonField(body: []const u8, key: []const u8, out: []u8) ?[]const u8 {
 const testing = std.testing;
 
 test "contentLength parsing" {
-    try testing.expectEqual(@as(?usize, 3), contentLength("HTTP/1.1 200 OK\r\nContent-Length: 3"));
-    try testing.expectEqual(@as(?usize, null), contentLength("HTTP/1.1 200 OK"));
+    try testing.expectEqual(@as(?u64, 3), contentLength("HTTP/1.1 200 OK\r\nContent-Length: 3"));
+    try testing.expectEqual(@as(?u64, null), contentLength("HTTP/1.1 200 OK"));
+}
+
+test "expectedLen waits for the header and caps Content-Length" {
+    try testing.expectEqual(@as(?usize, null), try expectedLen("HTTP/1.1 200 OK\r\nContent-Length: 3\r\n"));
+    try testing.expectEqual(@as(?usize, null), try expectedLen("HTTP/1.1 200 OK\r\n\r\nabc"));
+    const head = "HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\n";
+    try testing.expectEqual(@as(?usize, head.len + 3), try expectedLen(head ++ "a"));
+    try testing.expectError(error.ResponseTooLarge, expectedLen("HTTP/1.1 200 OK\r\nContent-Length: 1048577\r\n\r\n"));
+    try testing.expectError(error.ResponseTooLarge, expectedLen("HTTP/1.1 200 OK\r\nContent-Length: 18446744073709551615\r\n\r\n"));
+}
+
+test "parseResponse splits status and body" {
+    var r = try parseResponse(testing.allocator, "HTTP/1.1 404 Not Found\r\nContent-Length: 3\r\n\r\nabcdef");
+    defer r.deinit(testing.allocator);
+    try testing.expectEqual(@as(u16, 404), r.status);
+    try testing.expectEqualStrings("abc", r.body);
+
+    var r2 = try parseResponse(testing.allocator, "HTTP/1.1 200 OK\r\n\r\n{\"a\":1}");
+    defer r2.deinit(testing.allocator);
+    try testing.expectEqual(@as(u16, 200), r2.status);
+    try testing.expectEqualStrings("{\"a\":1}", r2.body);
+
+    try testing.expectError(error.BadResponse, parseResponse(testing.allocator, "HTTP/1.1 200 OK\r\n"));
+    try testing.expectError(error.BadResponse, parseResponse(testing.allocator, "HTTP/1.1 abc\r\n\r\n"));
+    try testing.expectError(error.BadResponse, parseResponse(testing.allocator, "\r\n\r\n"));
 }
 
 test "jsonField extracts value" {

--- a/host/integration_test.zig
+++ b/host/integration_test.zig
@@ -114,3 +114,81 @@ test "unclaimed sim refuses HCI connections" {
     tcp.close(io);
     try testing.expect(sim_future.await(io) != null);
 }
+
+fn runSilentPeer(io: Io, server: *Io.net.Server) void {
+    var stream = server.accept(io) catch return;
+    defer stream.close(io);
+    var buf: [16]u8 = undefined;
+    var r = stream.reader(io, &.{});
+    var vec = [_][]u8{&buf};
+    while (r.interface.readVec(&vec)) |_| {} else |_| {}
+}
+
+test "handshake gives up on a peer that never writes" {
+    const io = testing.io;
+    const listen_addr: Io.net.IpAddress = .{ .ip4 = .loopback(0) };
+    var server = try listen_addr.listen(io, .{ .reuse_address = true });
+    defer server.deinit(io);
+    var peer = try io.concurrent(runSilentPeer, .{ io, &server });
+
+    const tcp = try server.socket.address.connect(io, .{ .mode = .stream });
+    const psk: auth.Psk = [_]u8{4} ** 32;
+    const start = Io.Clock.Timestamp.now(io, .awake);
+    try testing.expectError(error.HandshakeTimeout, handshake.clientWith(io, tcp, &psk, .{ .timeout = .fromMilliseconds(200) }));
+    const elapsed_ms = start.untilNow(io).raw.toMilliseconds();
+    try testing.expect(elapsed_ms >= 150 and elapsed_ms < 1000);
+    tcp.close(io);
+    peer.await(io);
+}
+
+test "board sending a bad proof is AuthFailed, not a dead socket" {
+    const io = testing.io;
+    const listen_addr: Io.net.IpAddress = .{ .ip4 = .loopback(0) };
+    var server = try listen_addr.listen(io, .{ .reuse_address = true });
+    defer server.deinit(io);
+    const psk: auth.Psk = [_]u8{5} ** 32;
+    var ctrl: sim.Controller = .{ .psk = psk, .bad_mac = true };
+    var sim_future = try io.concurrent(runSimOnce, .{ io, &server, &ctrl });
+
+    const tcp = try server.socket.address.connect(io, .{ .mode = .stream });
+    try testing.expectError(error.AuthFailed, handshake.client(io, tcp, &psk));
+    tcp.close(io);
+    _ = sim_future.await(io);
+}
+
+fn runBoardThatHangsUp(io: Io, server: *Io.net.Server, psk: *const auth.Psk) void {
+    var stream = server.accept(io) catch return;
+    defer stream.close(io);
+    handshake.board(io, stream, psk) catch {};
+}
+
+test "session ends promptly when the board closes first" {
+    const io = testing.io;
+    const listen_addr: Io.net.IpAddress = .{ .ip4 = .loopback(0) };
+    var server = try listen_addr.listen(io, .{ .reuse_address = true });
+    defer server.deinit(io);
+    const psk: auth.Psk = [_]u8{6} ** 32;
+    var peer = try io.concurrent(runBoardThatHangsUp, .{ io, &server, &psk });
+
+    const tcp = try server.socket.address.connect(io, .{ .mode = .stream });
+    try session.tuneSocket(tcp.socket.handle);
+    try handshake.client(io, tcp, &psk);
+
+    var fds: [2]i32 = undefined;
+    const rc = std.os.linux.socketpair(std.os.linux.AF.UNIX, std.os.linux.SOCK.SEQPACKET | std.os.linux.SOCK.CLOEXEC, 0, &fds);
+    if (std.posix.errno(rc) != .SUCCESS) return error.SocketPairFailed;
+    const dummy: Io.net.IpAddress = .{ .ip4 = .loopback(0) };
+    const local: Io.net.Stream = .{ .socket = .{ .handle = fds[0], .address = dummy } };
+    const fake_host: Io.net.Stream = .{ .socket = .{ .handle = fds[1], .address = dummy } };
+    defer local.close(io);
+    defer fake_host.close(io);
+
+    var s = session.Session.init(io, tcp, .{ .socket = local });
+    const start = Io.Clock.Timestamp.now(io, .awake);
+    const stats = try s.run();
+    const elapsed_ms = start.untilNow(io).raw.toMilliseconds();
+    try testing.expect(elapsed_ms < 1000);
+    try testing.expectEqual(@as(u64, 0), stats.to_controller);
+    tcp.close(io);
+    peer.await(io);
+}

--- a/host/main.zig
+++ b/host/main.zig
@@ -173,7 +173,7 @@ fn clientThread(ctx: *ClientCtx) void {
             ctx.io.sleep(Io.Duration.fromMilliseconds(ctx.reconnect_ms), .awake) catch {};
             continue;
         };
-        _ = board.run(ctx.io, &addr, ctx.vhci, ctx.host, &ctx.psk) catch |err| {
+        _ = board.run(ctx.io, &addr, ctx.vhci, ctx.host, &ctx.psk, null) catch |err| {
             log.warn("[{s}] session ended: {s}", .{ ctx.host, @errorName(err) });
         };
         ctx.io.sleep(Io.Duration.fromMilliseconds(ctx.reconnect_ms), .awake) catch {};
@@ -232,8 +232,11 @@ fn runMode(io: Io, gpa: std.mem.Allocator, args: []const []const u8, env_map: *s
     // Pinned client boards each get their own reconnecting thread. A pinned
     // board is matched to a key by its address ("psk = <ip>=<hex>" works too),
     // or by the only key when there is exactly one.
+    var pinned: std.ArrayList([]const u8) = .empty;
+    defer pinned.deinit(gpa);
     for (s.clients) |client| {
         const hp = splitHostPort(client, s.port);
+        try pinned.append(gpa, hp.host);
         const psk = settings.lookupPsk(s.psk, hp.host) orelse
             (if (s.psk.len == 1) settings.lookupPsk(s.psk, s.psk[0][0 .. std.mem.indexOfScalar(u8, s.psk[0], '=') orelse 0]) else null) orelse {
             log.err("no key for pinned board {s}: run `hcibridge claim {s}`", .{ hp.host, hp.host });
@@ -244,7 +247,7 @@ fn runMode(io: Io, gpa: std.mem.Allocator, args: []const []const u8, env_map: *s
         if (s.once and s.clients.len == 1 and !s.discovery) {
             // one-shot for scripting/tests
             const addr = try Io.net.IpAddress.resolve(io, hp.host, hp.port);
-            _ = board.run(io, &addr, s.vhci, hp.host, &psk) catch {};
+            _ = board.run(io, &addr, s.vhci, hp.host, &psk, null) catch {};
             return 0;
         }
         const t = try std.Thread.spawn(.{}, clientThread, .{ctx});
@@ -262,6 +265,7 @@ fn runMode(io: Io, gpa: std.mem.Allocator, args: []const []const u8, env_map: *s
             .allow = s.allow,
             .deny = s.deny,
             .psk_entries = s.psk,
+            .pinned = pinned.items,
         });
         return 0;
     }

--- a/host/manager.zig
+++ b/host/manager.zig
@@ -21,7 +21,11 @@ pub const Options = struct {
     /// "bdaddr=hex" entries from `hcibridge claim`. Boards without one are
     /// never attached.
     psk_entries: []const []const u8 = &.{},
+    /// Hosts served by pinned client threads, their announces are ignored.
+    pinned: []const []const u8 = &.{},
 };
+
+const max_warned = 256;
 
 const Cidr = struct {
     base: u32,
@@ -29,13 +33,9 @@ const Cidr = struct {
     fn parse(text: []const u8) ?Cidr {
         const slash = std.mem.indexOfScalar(u8, text, '/') orelse return null;
         const ip = Io.net.Ip4Address.parse(text[0..slash], 0) catch return null;
-        const bits = std.fmt.parseInt(u5, text[slash + 1 ..], 10) catch {
-            // /32 and larger handled below; u5 maxes at 31
-            const b = std.fmt.parseInt(u8, text[slash + 1 ..], 10) catch return null;
-            if (b != 32) return null;
-            return .{ .base = std.mem.readInt(u32, &ip.bytes, .big), .mask = 0xffffffff };
-        };
-        const mask: u32 = if (bits == 0) 0 else @as(u32, 0xffffffff) << @intCast(32 - @as(u6, bits));
+        const bits = std.fmt.parseInt(u6, text[slash + 1 ..], 10) catch return null;
+        if (bits > 32) return null;
+        const mask: u32 = if (bits == 0) 0 else @as(u32, 0xffffffff) << @intCast(32 - bits);
         return .{ .base = std.mem.readInt(u32, &ip.bytes, .big), .mask = mask };
     }
     fn contains(self: Cidr, ip: [4]u8) bool {
@@ -53,31 +53,32 @@ fn permits(opts: Options, bdaddr: []const u8) bool {
 
 const Active = struct {
     mutex: Io.Mutex = .init,
-    set: std.StringHashMap(void),
-    gpa: std.mem.Allocator,
+    map: std.StringHashMap(*BoardCtx),
     io: Io,
 
     fn init(gpa: std.mem.Allocator, io: Io) Active {
-        return .{ .set = std.StringHashMap(void).init(gpa), .gpa = gpa, .io = io };
+        return .{ .map = std.StringHashMap(*BoardCtx).init(gpa), .io = io };
     }
 
-    /// Returns true if newly claimed (caller owns handling this bdaddr).
-    fn claim(self: *Active, bdaddr: []const u8) bool {
+    /// Returns true if newly claimed. A board back from another address gets its old link killed.
+    fn claim(self: *Active, ctx: *BoardCtx) bool {
         self.mutex.lockUncancelable(self.io);
         defer self.mutex.unlock(self.io);
-        if (self.set.contains(bdaddr)) return false;
-        const key = self.gpa.dupe(u8, bdaddr) catch return false;
-        self.set.put(key, {}) catch {
-            self.gpa.free(key);
+        if (self.map.get(ctx.bdaddr)) |old| {
+            if (!std.mem.eql(u8, &old.ip, &ctx.ip)) {
+                log.info("{s} ({s}) reappeared at {f}, was {f}, dropping the old link", .{ ctx.name, ctx.bdaddr, ctx.addr, old.addr });
+                old.link.kill(self.io);
+            }
             return false;
-        };
+        }
+        self.map.put(ctx.bdaddr, ctx) catch return false;
         return true;
     }
 
     fn release(self: *Active, bdaddr: []const u8) void {
         self.mutex.lockUncancelable(self.io);
         defer self.mutex.unlock(self.io);
-        if (self.set.fetchRemove(bdaddr)) |kv| self.gpa.free(kv.key);
+        _ = self.map.remove(bdaddr);
     }
 };
 
@@ -86,26 +87,49 @@ const BoardCtx = struct {
     gpa: std.mem.Allocator,
     active: *Active,
     addr: Io.net.IpAddress,
+    ip: [4]u8,
     bdaddr: []u8,
     name: []u8,
     vhci_path: []const u8,
     psk: auth.Psk,
+    link: board.Link = .{},
+
+    fn destroy(ctx: *BoardCtx) void {
+        ctx.gpa.free(ctx.bdaddr);
+        ctx.gpa.free(ctx.name);
+        ctx.gpa.destroy(ctx);
+    }
 };
 
 fn boardThread(ctx: *BoardCtx) void {
-    _ = board.run(ctx.io, &ctx.addr, ctx.vhci_path, ctx.name, &ctx.psk) catch |err| {
-        log.warn("[{s}] session ended: {s}", .{ ctx.name, @errorName(err) });
+    const backoff_ms: u32 = if (board.run(ctx.io, &ctx.addr, ctx.vhci_path, ctx.name, &ctx.psk, &ctx.link)) |_| 500 else |err| switch (err) {
+        error.AuthFailed => blk: {
+            log.warn("[{s}] session ended: {s}", .{ ctx.name, @errorName(err) });
+            break :blk 5000;
+        },
+        error.VhciOpen => blk: {
+            log.err("[{s}] cannot open {s}: load the hci_vhci module and run as root, retrying in 10 s", .{ ctx.name, ctx.vhci_path });
+            break :blk 10_000;
+        },
+        else => blk: {
+            log.warn("[{s}] session ended: {s}", .{ ctx.name, @errorName(err) });
+            break :blk 500;
+        },
     };
+    // Back off while still claimed so a flapping board cannot start a second session.
+    ctx.io.sleep(Io.Duration.fromMilliseconds(backoff_ms), .awake) catch {};
     ctx.active.release(ctx.bdaddr);
-    // Small settle so we do not thrash if the board is flapping.
-    ctx.io.sleep(Io.Duration.fromMilliseconds(500), .awake) catch {};
-    ctx.gpa.free(ctx.bdaddr);
-    ctx.gpa.free(ctx.name);
-    ctx.gpa.destroy(ctx);
+    ctx.destroy();
+}
+
+fn isPinned(pinned: []const [4]u8, ip: [4]u8) bool {
+    for (pinned) |p| if (std.mem.eql(u8, &p, &ip)) return true;
+    return false;
 }
 
 pub fn run(io: Io, gpa: std.mem.Allocator, opts: Options) !void {
     var active = Active.init(gpa, io);
+    defer active.map.deinit();
     // Unclaimed boards are logged once each, not every 2 s.
     var warned = std.StringHashMap(void).init(gpa);
     defer {
@@ -114,11 +138,35 @@ pub fn run(io: Io, gpa: std.mem.Allocator, opts: Options) !void {
         warned.deinit();
     }
 
-    const bind_ip = Io.net.Ip4Address.parse(opts.bind, opts.discovery_port) catch Io.net.Ip4Address.unspecified(opts.discovery_port);
+    const bind_ip = Io.net.Ip4Address.parse(opts.bind, opts.discovery_port) catch |err| {
+        log.err("bad bind address {s}: {s}", .{ opts.bind, @errorName(err) });
+        return error.BadBindAddress;
+    };
+    const subnet: ?Cidr = if (opts.subnet.len == 0) null else Cidr.parse(opts.subnet) orelse {
+        log.err("bad subnet {s}: want a.b.c.d/bits", .{opts.subnet});
+        return error.BadSubnet;
+    };
+
+    var pinned: std.ArrayList([4]u8) = .empty;
+    defer pinned.deinit(gpa);
+    for (opts.pinned) |host| {
+        const addr = Io.net.IpAddress.resolve(io, host, 0) catch |err| {
+            log.warn("pinned board {s}: {s}, discovery may attach it a second time", .{ host, @errorName(err) });
+            continue;
+        };
+        switch (addr) {
+            .ip4 => |v4| try pinned.append(gpa, v4.bytes),
+            else => {},
+        }
+    }
+
     const bind_addr: Io.net.IpAddress = .{ .ip4 = bind_ip };
     const sock = try bind_addr.bind(io, .{ .mode = .dgram, .allow_broadcast = true });
     defer sock.close(io);
     log.info("discovery listening on udp {d}, probing for bridges", .{opts.discovery_port});
+    if (!std.mem.eql(u8, &bind_ip.bytes, &.{ 0, 0, 0, 0 })) {
+        log.warn("bound to {s}: broadcast announces are not delivered to a unicast bind, boards are found by probe replies only", .{opts.bind});
+    }
 
     const bcast: Io.net.IpAddress = .{ .ip4 = .{ .bytes = .{ 255, 255, 255, 255 }, .port = opts.discovery_port } };
     var probe_buf: [64]u8 = undefined;
@@ -154,10 +202,20 @@ pub fn run(io: Io, gpa: std.mem.Allocator, opts: Options) !void {
         };
 
         if (!permits(opts, ann.bdaddr)) continue;
+        const from_ip: [4]u8 = switch (msg.from) {
+            .ip4 => |v4| v4.bytes,
+            else => continue,
+        };
+        if (isPinned(pinned.items, from_ip)) continue;
 
         // Only boards we hold a key for, and only announces they signed.
         const psk = settings.lookupPsk(opts.psk_entries, ann.bdaddr) orelse {
             if (!warned.contains(ann.bdaddr)) {
+                if (warned.count() >= max_warned) {
+                    var it = warned.keyIterator();
+                    while (it.next()) |k| gpa.free(k.*);
+                    warned.clearRetainingCapacity();
+                }
                 if (gpa.dupe(u8, ann.bdaddr)) |k| warned.put(k, {}) catch gpa.free(k) else |_| {}
                 var abuf: [24]u8 = undefined;
                 const astr = std.fmt.bufPrint(&abuf, "{f}", .{msg.from}) catch "?";
@@ -165,45 +223,27 @@ pub fn run(io: Io, gpa: std.mem.Allocator, opts: Options) !void {
             }
             continue;
         };
-        const from_ip: [4]u8 = switch (msg.from) {
-            .ip4 => |v4| v4.bytes,
-            else => continue,
-        };
         if (!auth.verifyAnnounce(&psk, ann.bdaddr, ann.port, ann.name, from_ip, ann.sig)) {
             log.warn("ignoring announce for {s} with a bad signature (spoofed, replayed, or stale key)", .{ann.bdaddr});
             continue;
         }
-
-        if (opts.subnet.len > 0) {
-            if (Cidr.parse(opts.subnet)) |cidr| {
-                switch (msg.from) {
-                    .ip4 => |v4| if (!cidr.contains(v4.bytes)) continue,
-                    else => continue,
-                }
-            }
-        }
-        if (!active.claim(ann.bdaddr)) continue;
+        if (subnet) |cidr| if (!cidr.contains(from_ip)) continue;
 
         var addr = msg.from;
         addr.setPort(ann.port);
-        log.info("discovered {s} ({s}) at {f}", .{ ann.name, ann.bdaddr, addr });
 
-        const ctx = gpa.create(BoardCtx) catch {
-            active.release(ann.bdaddr);
-            continue;
-        };
+        const ctx = gpa.create(BoardCtx) catch continue;
         ctx.* = .{
             .io = io,
             .gpa = gpa,
             .active = &active,
             .addr = addr,
+            .ip = from_ip,
             .bdaddr = gpa.dupe(u8, ann.bdaddr) catch {
-                active.release(ann.bdaddr);
                 gpa.destroy(ctx);
                 continue;
             },
             .name = gpa.dupe(u8, ann.name) catch {
-                active.release(ann.bdaddr);
                 gpa.free(ctx.bdaddr);
                 gpa.destroy(ctx);
                 continue;
@@ -211,15 +251,60 @@ pub fn run(io: Io, gpa: std.mem.Allocator, opts: Options) !void {
             .vhci_path = opts.vhci_path,
             .psk = psk,
         };
+        if (!active.claim(ctx)) {
+            ctx.destroy();
+            continue;
+        }
+        log.info("discovered {s} ({s}) at {f}", .{ ann.name, ann.bdaddr, addr });
 
         const t = std.Thread.spawn(.{}, boardThread, .{ctx}) catch |err| {
             log.err("cannot spawn board thread: {s}", .{@errorName(err)});
-            active.release(ann.bdaddr);
-            gpa.free(ctx.bdaddr);
-            gpa.free(ctx.name);
-            gpa.destroy(ctx);
+            active.release(ctx.bdaddr);
+            ctx.destroy();
             continue;
         };
         t.detach();
     }
+}
+
+const testing = std.testing;
+
+test "cidr parse accepts every prefix length" {
+    const any = Cidr.parse("0.0.0.0/0").?;
+    try testing.expectEqual(@as(u32, 0), any.mask);
+    const eight = Cidr.parse("10.0.0.0/8").?;
+    try testing.expectEqual(@as(u32, 0xff000000), eight.mask);
+    try testing.expectEqual(@as(u32, 0x0a000000), eight.base);
+    const c = Cidr.parse("192.168.1.0/24").?;
+    try testing.expectEqual(@as(u32, 0xffffff00), c.mask);
+    const host = Cidr.parse("172.16.135.242/32").?;
+    try testing.expectEqual(@as(u32, 0xffffffff), host.mask);
+    try testing.expectEqual(@as(u32, 0xac1087f2), host.base);
+}
+
+test "cidr parse rejects malformed input" {
+    try testing.expect(Cidr.parse("10.0.0.0") == null);
+    try testing.expect(Cidr.parse("10.0.0.0/") == null);
+    try testing.expect(Cidr.parse("10.0.0.0/33") == null);
+    try testing.expect(Cidr.parse("10.0.0.0/-1") == null);
+    try testing.expect(Cidr.parse("10.0.0.0/x") == null);
+    try testing.expect(Cidr.parse("/24") == null);
+    try testing.expect(Cidr.parse("10.0.0/24") == null);
+    try testing.expect(Cidr.parse("garbage") == null);
+    try testing.expect(Cidr.parse("") == null);
+}
+
+test "cidr contains" {
+    const lan = Cidr.parse("192.168.1.0/24").?;
+    try testing.expect(lan.contains(.{ 192, 168, 1, 77 }));
+    try testing.expect(lan.contains(.{ 192, 168, 1, 0 }));
+    try testing.expect(!lan.contains(.{ 192, 168, 2, 1 }));
+    const any = Cidr.parse("0.0.0.0/0").?;
+    try testing.expect(any.contains(.{ 8, 8, 8, 8 }));
+    const one = Cidr.parse("10.1.2.3/32").?;
+    try testing.expect(one.contains(.{ 10, 1, 2, 3 }));
+    try testing.expect(!one.contains(.{ 10, 1, 2, 4 }));
+    // Base bits below the mask are ignored, so 10.1.2.3/8 behaves like 10.0.0.0/8.
+    const sloppy = Cidr.parse("10.1.2.3/8").?;
+    try testing.expect(sloppy.contains(.{ 10, 200, 0, 1 }));
 }

--- a/host/manager.zig
+++ b/host/manager.zig
@@ -165,8 +165,12 @@ pub fn run(io: Io, gpa: std.mem.Allocator, opts: Options) !void {
             }
             continue;
         };
-        if (!auth.verifyAnnounce(&psk, ann.bdaddr, ann.port, ann.name, ann.sig)) {
-            log.warn("ignoring announce for {s} with a bad signature (spoofed or stale key)", .{ann.bdaddr});
+        const from_ip: [4]u8 = switch (msg.from) {
+            .ip4 => |v4| v4.bytes,
+            else => continue,
+        };
+        if (!auth.verifyAnnounce(&psk, ann.bdaddr, ann.port, ann.name, from_ip, ann.sig)) {
+            log.warn("ignoring announce for {s} with a bad signature (spoofed, replayed, or stale key)", .{ann.bdaddr});
             continue;
         }
 

--- a/host/openrc/hcibridged.confd
+++ b/host/openrc/hcibridged.confd
@@ -2,7 +2,6 @@
 # Leave BRIDGE_HOST empty for auto-discovery (finds every bridge on the LAN,
 # each gets its own adapter). Set it to pin a single board and skip discovery.
 BRIDGE_HOST=""
-BRIDGE_PORT="4444"
 BRIDGE_VHCI="/dev/vhci"
 # Extra flags, e.g. "--reconnect-ms 500"
 BRIDGE_ARGS=""

--- a/host/session.zig
+++ b/host/session.zig
@@ -67,7 +67,11 @@ pub const Session = struct {
     /// packet counters. A clean remote close is not an error.
     pub fn run(self: *Session) !Stats {
         var to_local = try self.io.concurrent(pumpTcpToLocal, .{self});
-        var to_tcp = try self.io.concurrent(pumpLocalToTcp, .{self});
+        var to_tcp = self.io.concurrent(pumpLocalToTcp, .{self}) catch |err| {
+            self.shutdown();
+            to_local.await(self.io);
+            return err;
+        };
         to_local.await(self.io);
         to_tcp.await(self.io);
         if (self.first_error) |err| return err;
@@ -168,4 +172,7 @@ pub fn tuneSocket(fd: posix.fd_t) !void {
     try posix.setsockopt(fd, posix.IPPROTO.TCP, linux.TCP.KEEPIDLE, std.mem.asBytes(&idle));
     try posix.setsockopt(fd, posix.IPPROTO.TCP, linux.TCP.KEEPINTVL, std.mem.asBytes(&intvl));
     try posix.setsockopt(fd, posix.IPPROTO.TCP, linux.TCP.KEEPCNT, std.mem.asBytes(&cnt));
+    // Caps retransmit backoff so a board that dies mid-traffic drops the session quickly.
+    const user_timeout_ms: c_uint = 10_000;
+    try posix.setsockopt(fd, posix.IPPROTO.TCP, linux.TCP.USER_TIMEOUT, std.mem.asBytes(&user_timeout_ms));
 }

--- a/host/settings.zig
+++ b/host/settings.zig
@@ -27,17 +27,17 @@ pub const Desc = struct {
 
 /// The schema. Everything downstream is generated from this.
 pub const descs = [_]Desc{
-    .{ .field = "discovery", .flag = "--discovery", .env = "HCIBRIDGE_DISCOVERY", .key = "discovery", .kind = .boolean, .arg = "on|off", .help = "auto-discover bridges on the LAN (default on; --no-discovery to disable)" },
+    .{ .field = "discovery", .flag = "--discovery", .env = "HCIBRIDGE_DISCOVERY", .key = "discovery", .kind = .boolean, .arg = "on|off", .help = "auto-discover bridges on the LAN (default on, --no-discovery turns it off)" },
     .{ .field = "bind", .flag = "--bind", .env = "HCIBRIDGE_BIND", .key = "bind", .kind = .str, .arg = "ip", .help = "address to listen on for discovery (default 0.0.0.0)" },
     .{ .field = "subnet", .flag = "--subnet", .env = "HCIBRIDGE_SUBNET", .key = "subnet", .kind = .str, .arg = "cidr", .help = "only attach boards whose IP is in this range, e.g. 172.16.0.0/16" },
     .{ .field = "discovery_port", .flag = "--discovery-port", .env = "HCIBRIDGE_DISCOVERY_PORT", .key = "discovery-port", .kind = .port, .arg = "n", .help = "UDP discovery port (default 4445)" },
     .{ .field = "port", .flag = "--port", .env = "HCIBRIDGE_PORT", .key = "port", .kind = .port, .arg = "n", .help = "default board TCP port (default 4444)" },
     .{ .field = "vhci", .flag = "--vhci", .env = "HCIBRIDGE_VHCI", .key = "vhci", .kind = .str, .arg = "path", .help = "virtual HCI device (default /dev/vhci)" },
     .{ .field = "reconnect_ms", .flag = "--reconnect-ms", .env = "HCIBRIDGE_RECONNECT_MS", .key = "reconnect-ms", .kind = .u32v, .arg = "n", .help = "reconnect delay for pinned boards (default 1000)" },
-    .{ .field = "clients", .flag = "--client", .env = "HCIBRIDGE_CLIENTS", .key = "client", .kind = .list, .arg = "ip", .help = "static ESP board to attach (repeatable); disables the need for discovery" },
+    .{ .field = "clients", .flag = "--client", .env = "HCIBRIDGE_CLIENTS", .key = "client", .kind = .list, .arg = "ip", .help = "static ESP board to attach (repeatable), removes the need for discovery" },
     .{ .field = "allow", .flag = "--allow", .env = "HCIBRIDGE_ALLOW", .key = "allow", .kind = .list, .arg = "bdaddr", .help = "only attach boards with these Bluetooth addresses (repeatable)" },
     .{ .field = "deny", .flag = "--deny", .env = "HCIBRIDGE_DENY", .key = "deny", .kind = .list, .arg = "bdaddr", .help = "never attach boards with these Bluetooth addresses (repeatable)" },
-    .{ .field = "psk", .flag = "--psk", .env = "HCIBRIDGE_PSK", .key = "psk", .kind = .list, .arg = "bdaddr=hex", .help = "board key from 'hcibridge claim' (repeatable); only keyed boards are attached" },
+    .{ .field = "psk", .flag = "--psk", .env = "HCIBRIDGE_PSK", .key = "psk", .kind = .list, .arg = "bdaddr=hex", .help = "board key from hcibridge claim (repeatable), only keyed boards are attached" },
 };
 
 pub const Settings = struct {
@@ -61,20 +61,45 @@ pub const Settings = struct {
 };
 
 /// Finds the PSK for a board among "bdaddr=hex" entries (bdaddr case-insensitive).
+/// Entries are ordered by precedence, so the last valid match wins.
 pub fn lookupPsk(entries: []const []const u8, bdaddr: []const u8) ?auth.Psk {
-    for (entries) |e| {
+    var i = entries.len;
+    while (i > 0) {
+        i -= 1;
+        const e = entries[i];
         const eq = std.mem.indexOfScalar(u8, e, '=') orelse continue;
         if (!std.ascii.eqlIgnoreCase(std.mem.trim(u8, e[0..eq], " "), bdaddr)) continue;
-        return auth.hexToPsk(std.mem.trim(u8, e[eq + 1 ..], " "));
+        if (auth.hexToPsk(std.mem.trim(u8, e[eq + 1 ..], " "))) |p| return p;
+        log.warn("ignoring malformed psk entry for {s} (want 64 hex chars)", .{bdaddr});
     }
     return null;
 }
 
 pub const EnvGet = *const fn (ctx: ?*anyopaque, name: []const u8) ?[]const u8;
 
+/// One value on its way into a Settings field, with where it came from for diagnostics.
+const Layer = struct {
+    field: []const u8,
+    name: []const u8,
+    value: []const u8,
+    src: []const u8,
+};
+
 fn descByFlag(flag: []const u8) ?Desc {
     for (descs) |d| if (std.mem.eql(u8, d.flag, flag)) return d;
     return null;
+}
+
+fn descByKey(key: []const u8) ?Desc {
+    for (descs) |d| if (std.mem.eql(u8, d.key, key)) return d;
+    return null;
+}
+
+fn parseIntOr(comptime T: type, l: Layer, fallback: T) T {
+    return std.fmt.parseInt(T, l.value, 10) catch {
+        log.warn("{s}: ignoring {s} = {s} (want a number 0..{d})", .{ l.src, l.name, l.value, std.math.maxInt(T) });
+        return fallback;
+    };
 }
 
 fn parseBool(v: []const u8) ?bool {
@@ -100,16 +125,16 @@ pub fn resolve(
 
     // Build one ordered list of field/value pairs: conf, then env, then flags.
     // Scalars resolve to the last matching entry (so flags win); lists take all.
-    var layered: std.ArrayList(config.Pair) = .empty;
+    var layered: std.ArrayList(Layer) = .empty;
     defer layered.deinit(gpa);
 
     // conf: map file keys -> field names
     for (conf_pairs) |p| {
-        for (descs) |d| {
-            if (std.mem.eql(u8, d.key, p.key)) {
-                try layered.append(gpa, .{ .key = d.field, .value = p.value });
-            }
-        }
+        const d = descByKey(p.key) orelse {
+            log.warn("{s}: unknown key {s}", .{ p.source, p.key });
+            continue;
+        };
+        try layered.append(gpa, .{ .field = d.field, .name = d.key, .value = p.value, .src = p.source });
     }
     // env
     if (env_get) |get| {
@@ -119,10 +144,10 @@ pub fn resolve(
                     var it = std.mem.splitScalar(u8, v, ',');
                     while (it.next()) |item| {
                         const t = std.mem.trim(u8, item, " ");
-                        if (t.len > 0) try layered.append(gpa, .{ .key = d.field, .value = t });
+                        if (t.len > 0) try layered.append(gpa, .{ .field = d.field, .name = d.env, .value = t, .src = "env" });
                     }
                 } else {
-                    try layered.append(gpa, .{ .key = d.field, .value = v });
+                    try layered.append(gpa, .{ .field = d.field, .name = d.env, .value = v, .src = "env" });
                 }
             }
         }
@@ -139,12 +164,12 @@ pub fn resolve(
             // sugar: pin one board and turn discovery off
             i += 1;
             if (i >= args.len) return error.MissingValue;
-            try layered.append(gpa, .{ .key = "clients", .value = args[i] });
-            try layered.append(gpa, .{ .key = "discovery", .value = "off" });
+            try layered.append(gpa, .{ .field = "clients", .name = arg, .value = args[i], .src = "flag" });
+            try layered.append(gpa, .{ .field = "discovery", .name = arg, .value = "off", .src = "flag" });
             continue;
         }
         if (std.mem.eql(u8, arg, "--no-discovery")) {
-            try layered.append(gpa, .{ .key = "discovery", .value = "off" });
+            try layered.append(gpa, .{ .field = "discovery", .name = arg, .value = "off", .src = "flag" });
             continue;
         }
         if (std.mem.startsWith(u8, arg, "--")) {
@@ -153,14 +178,14 @@ pub fn resolve(
                 // optional value; bare flag means on
                 if (i + 1 < args.len and parseBool(args[i + 1]) != null) {
                     i += 1;
-                    try layered.append(gpa, .{ .key = d.field, .value = args[i] });
+                    try layered.append(gpa, .{ .field = d.field, .name = d.flag, .value = args[i], .src = "flag" });
                 } else {
-                    try layered.append(gpa, .{ .key = d.field, .value = "on" });
+                    try layered.append(gpa, .{ .field = d.field, .name = d.flag, .value = "on", .src = "flag" });
                 }
             } else {
                 i += 1;
                 if (i >= args.len) return error.MissingValue;
-                try layered.append(gpa, .{ .key = d.field, .value = args[i] });
+                try layered.append(gpa, .{ .field = d.field, .name = d.flag, .value = args[i], .src = "flag" });
             }
             continue;
         }
@@ -174,27 +199,30 @@ pub fn resolve(
     var psk: std.ArrayList([]const u8) = .empty;
 
     for (layered.items) |p| {
-        if (std.mem.eql(u8, p.key, "discovery")) {
-            s.discovery = parseBool(p.value) orelse s.discovery;
-        } else if (std.mem.eql(u8, p.key, "bind")) {
+        if (std.mem.eql(u8, p.field, "discovery")) {
+            s.discovery = parseBool(p.value) orelse blk: {
+                log.warn("{s}: ignoring {s} = {s} (want on or off)", .{ p.src, p.name, p.value });
+                break :blk s.discovery;
+            };
+        } else if (std.mem.eql(u8, p.field, "bind")) {
             s.bind = try a.dupe(u8, p.value);
-        } else if (std.mem.eql(u8, p.key, "subnet")) {
+        } else if (std.mem.eql(u8, p.field, "subnet")) {
             s.subnet = try a.dupe(u8, p.value);
-        } else if (std.mem.eql(u8, p.key, "discovery_port")) {
-            s.discovery_port = std.fmt.parseInt(u16, p.value, 10) catch s.discovery_port;
-        } else if (std.mem.eql(u8, p.key, "port")) {
-            s.port = std.fmt.parseInt(u16, p.value, 10) catch s.port;
-        } else if (std.mem.eql(u8, p.key, "vhci")) {
+        } else if (std.mem.eql(u8, p.field, "discovery_port")) {
+            s.discovery_port = parseIntOr(u16, p, s.discovery_port);
+        } else if (std.mem.eql(u8, p.field, "port")) {
+            s.port = parseIntOr(u16, p, s.port);
+        } else if (std.mem.eql(u8, p.field, "vhci")) {
             s.vhci = try a.dupe(u8, p.value);
-        } else if (std.mem.eql(u8, p.key, "reconnect_ms")) {
-            s.reconnect_ms = std.fmt.parseInt(u32, p.value, 10) catch s.reconnect_ms;
-        } else if (std.mem.eql(u8, p.key, "clients")) {
+        } else if (std.mem.eql(u8, p.field, "reconnect_ms")) {
+            s.reconnect_ms = parseIntOr(u32, p, s.reconnect_ms);
+        } else if (std.mem.eql(u8, p.field, "clients")) {
             try clients.append(a, try a.dupe(u8, p.value));
-        } else if (std.mem.eql(u8, p.key, "allow")) {
+        } else if (std.mem.eql(u8, p.field, "allow")) {
             try allow.append(a, try a.dupe(u8, p.value));
-        } else if (std.mem.eql(u8, p.key, "deny")) {
+        } else if (std.mem.eql(u8, p.field, "deny")) {
             try deny.append(a, try a.dupe(u8, p.value));
-        } else if (std.mem.eql(u8, p.key, "psk")) {
+        } else if (std.mem.eql(u8, p.field, "psk")) {
             try psk.append(a, try a.dupe(u8, p.value));
         }
     }
@@ -217,8 +245,6 @@ pub fn writeOptions(w: *std.Io.Writer) !void {
         while (pad > 0) : (pad -= 1) try w.writeByte(' ');
         try w.print("{s}  [env {s}]\n", .{ d.help, d.env });
     }
-    try w.writeAll("  --host <addr>              pin one board and disable discovery (sugar)\n");
-    try w.writeAll("  --config <path>            config file (default /etc/hcibridge/config; .d drop-ins)\n");
 }
 
 const testing = std.testing;
@@ -293,4 +319,28 @@ test "lookupPsk matches case-insensitively and parses hex" {
     const p = lookupPsk(&entries, "aa:bb:cc:dd:ee:01").?;
     try testing.expectEqual(@as(u8, 0xab), p[0]);
     try testing.expect(lookupPsk(&entries, "aa:bb:cc:dd:ee:02") == null);
+}
+
+test "lookupPsk takes the last entry and skips malformed ones" {
+    const later = [_][]const u8{ "aa:bb:cc:dd:ee:01=" ++ ("ab" ** 32), "aa:bb:cc:dd:ee:01=" ++ ("cd" ** 32) };
+    try testing.expectEqual(@as(u8, 0xcd), lookupPsk(&later, "aa:bb:cc:dd:ee:01").?[0]);
+
+    const malformed = [_][]const u8{ "aa:bb:cc:dd:ee:01=nothex", "aa:bb:cc:dd:ee:01=" ++ ("ab" ** 32), "aa:bb:cc:dd:ee:01=1234" };
+    try testing.expectEqual(@as(u8, 0xab), lookupPsk(&malformed, "aa:bb:cc:dd:ee:01").?[0]);
+    try testing.expect(lookupPsk(&.{"aa:bb:cc:dd:ee:01=zz"}, "aa:bb:cc:dd:ee:01") == null);
+}
+
+test "bad values fall back and unknown keys are ignored" {
+    const conf = [_]config.Pair{
+        .{ .key = "port", .value = "70000" },
+        .{ .key = "reconnect-ms", .value = "1s" },
+        .{ .key = "no-such-key", .value = "1" },
+    };
+    TestEnv.pairs = &.{.{ "HCIBRIDGE_DISCOVERY", "maybe" }};
+    var s = try resolve(testing.allocator, &conf, &.{}, TestEnv.get, null);
+    defer s.deinit();
+    try testing.expectEqual(@as(u16, 4444), s.port);
+    try testing.expectEqual(@as(u32, 1000), s.reconnect_ms);
+    try testing.expect(s.discovery);
+    TestEnv.pairs = &.{};
 }

--- a/host/sim.zig
+++ b/host/sim.zig
@@ -16,6 +16,8 @@ pub const Controller = struct {
     commands: u64 = 0,
     /// Board key. Null means unclaimed: HCI connections are refused, like the firmware.
     psk: ?auth.Psk = null,
+    /// Test hook: answer the handshake with a proof made from the wrong key.
+    bad_mac: bool = false,
 
     const Opcode = struct {
         const reset: u16 = 0x0c03;
@@ -75,7 +77,7 @@ pub const Controller = struct {
                 plen = 9;
             },
             Opcode.read_local_ext_features => {
-                const page = if (pkt.len > 3) pkt[3] else 0;
+                const page = if (pkt.len > 4) pkt[4] else 0;
                 params[1] = page;
                 params[2] = 2;
                 @memset(params[3..11], 0);
@@ -126,7 +128,9 @@ pub fn serve(io: Io, stream: Io.net.Stream, ctrl: *Controller) !void {
         log.warn("unclaimed: refusing HCI connection", .{});
         return error.Unclaimed;
     };
-    try handshake.board(io, stream, &psk);
+    var wrong: auth.Psk = psk;
+    wrong[0] +%= 1;
+    try handshake.boardWith(io, stream, &psk, .{ .reply_psk = if (ctrl.bad_mac) &wrong else null });
     var read_buf: [4096]u8 = undefined;
     var write_buf: [4096]u8 = undefined;
     var storage: [h4.max_packet_len]u8 = undefined;

--- a/host/sim.zig
+++ b/host/sim.zig
@@ -164,6 +164,7 @@ const AnnounceCfg = struct {
     name: []const u8,
     disc_port: u16,
     psk: ?auth.Psk,
+    ip: [4]u8,
 };
 
 fn announceLoop(cfg: AnnounceCfg) void {
@@ -174,7 +175,7 @@ fn announceLoop(cfg: AnnounceCfg) void {
     defer sock.close(cfg.io);
     var buf: [disc.max_datagram]u8 = undefined;
     var sigbuf: [auth.announce_sig_hex_len]u8 = undefined;
-    const sig: []const u8 = if (cfg.psk) |*p| auth.announceSig(p, cfg.bdaddr, cfg.tcp_port, cfg.name, &sigbuf) else "-";
+    const sig: []const u8 = if (cfg.psk) |*p| auth.announceSig(p, cfg.bdaddr, cfg.tcp_port, cfg.name, cfg.ip, &sigbuf) else "-";
     const msg = disc.buildAnnounce(&buf, cfg.bdaddr, cfg.tcp_port, cfg.name, sig) catch return;
     while (true) {
         sock.send(cfg.io, &cfg.to, msg) catch |err| log.debug("announce send: {s}", .{@errorName(err)});
@@ -190,6 +191,8 @@ pub fn main(init: std.process.Init) !void {
     var announce_to: ?[]const u8 = null;
     var disc_port: u16 = disc.default_port;
     var psk: ?auth.Psk = null;
+    // Address the host will see announces come from. Signed into the announce.
+    var own_ip: [4]u8 = .{ 127, 0, 0, 1 };
     var it = init.minimal.args.iterate();
     _ = it.next();
     while (it.next()) |arg| {
@@ -203,10 +206,13 @@ pub fn main(init: std.process.Init) !void {
             announce_to = it.next() orelse return error.MissingValue;
         } else if (std.mem.eql(u8, arg, "--discovery-port")) {
             disc_port = try std.fmt.parseInt(u16, it.next() orelse return error.MissingValue, 10);
+        } else if (std.mem.eql(u8, arg, "--ip")) {
+            const a = try Io.net.Ip4Address.parse(it.next() orelse return error.MissingValue, 0);
+            own_ip = a.bytes;
         } else if (std.mem.eql(u8, arg, "--psk")) {
             psk = auth.hexToPsk(it.next() orelse return error.MissingValue) orelse return error.BadPsk;
         } else {
-            log.err("usage: hcibridge-sim [--port n] [--bdaddr x] [--name x] [--announce-to ip:port] [--discovery-port n] [--psk hex]", .{});
+            log.err("usage: hcibridge-sim [--port n] [--bdaddr x] [--name x] [--announce-to ip:port] [--discovery-port n] [--psk hex] [--ip a.b.c.d]", .{});
             return error.BadArgument;
         }
     }
@@ -235,6 +241,7 @@ pub fn main(init: std.process.Init) !void {
         .name = name,
         .disc_port = disc_port,
         .psk = psk,
+        .ip = own_ip,
     }});
     defer _ = announce.cancel(io);
 

--- a/host/spec.zig
+++ b/host/spec.zig
@@ -29,6 +29,17 @@ pub const global_opts = [_]Opt{
     .{ .long = "--help", .short = "-h", .help = "show help" },
 };
 
+const config_opt = Opt{ .long = "--config", .arg = "path", .help = "config file (default /etc/hcibridge/config, plus .d drop-ins)" };
+const discovery_port_opt = Opt{ .long = "--discovery-port", .arg = "n", .help = "UDP discovery port (default 4445)" };
+
+/// Run flags handled by main.zig rather than the settings schema.
+pub const run_extras = [_]Opt{
+    .{ .long = "--host", .arg = "addr", .help = "pin one board and disable discovery (sugar)" },
+    .{ .long = "--no-discovery", .help = "disable discovery" },
+    config_opt,
+    .{ .long = "--once", .help = "exit after the first session of a single pinned board" },
+};
+
 pub const commands = [_]Cmd{
     .{
         .name = "run",
@@ -37,32 +48,30 @@ pub const commands = [_]Cmd{
     .{
         .name = "list",
         .summary = "discover bridges and print their firmware versions",
-        .opts = &.{
-            .{ .long = "--discovery-port", .arg = "n", .help = "UDP discovery port (default 4445)" },
-        },
+        .opts = &.{discovery_port_opt},
     },
     .{
         .name = "status",
-        .summary = "print one bridge's full status",
+        .summary = "print full status of one bridge",
         .args = "<ip>",
     },
     .{
         .name = "claim",
         .summary = "pair with an unclaimed bridge: agree a key and save it to the config",
         .args = "<ip>",
+        .opts = &.{config_opt},
     },
     .{
         .name = "reboot",
         .summary = "reboot a bridge (requires its key)",
         .args = "<ip>",
+        .opts = &.{config_opt},
     },
     .{
         .name = "update",
         .summary = "push a firmware image over OTA to one bridge or all (requires keys)",
         .args = "<ip|all> <file>",
-        .opts = &.{
-            .{ .long = "--discovery-port", .arg = "n", .help = "UDP discovery port (default 4445)" },
-        },
+        .opts = &.{ discovery_port_opt, config_opt },
     },
     .{
         .name = "completions",
@@ -75,6 +84,25 @@ pub const commands = [_]Cmd{
 };
 
 pub const shells = [_][]const u8{ "bash", "zsh", "fish" };
+
+/// Text for a single-quoted zsh or fish string, printed with `{f}`.
+const Sq = struct {
+    s: []const u8,
+
+    pub fn format(self: Sq, w: *std.Io.Writer) std.Io.Writer.Error!void {
+        for (self.s) |c| {
+            if (c == '\'') try w.writeAll("'\\''") else try w.writeByte(c);
+        }
+    }
+};
+
+fn sq(s: []const u8) Sq {
+    return .{ .s = s };
+}
+
+fn descOpt(d: settings.Desc) Opt {
+    return .{ .long = d.flag, .arg = d.arg, .help = d.help };
+}
 
 // ---------------------------------------------------------------------------
 // Help
@@ -93,22 +121,23 @@ pub fn writeHelp(w: *std.Io.Writer) !void {
     for (commands) |c| {
         if (c.opts.len == 0) continue;
         try w.print("\n{s} options:\n", .{c.name});
-        for (c.opts) |o| try writeOptLine(w, o);
+        for (c.opts) |o| try writeOptLine(w, o, 22);
     }
     try w.print("\nrun options:\n", .{});
     try settings.writeOptions(w);
+    for (run_extras) |o| try writeOptLine(w, o, 26);
     try w.print("\nglobal:\n", .{});
-    for (global_opts) |o| try writeOptLine(w, o);
+    for (global_opts) |o| try writeOptLine(w, o, 22);
 }
 
-fn writeOptLine(w: *std.Io.Writer, o: Opt) !void {
+fn writeOptLine(w: *std.Io.Writer, o: Opt, width: usize) !void {
     var buf: [48]u8 = undefined;
     const head = if (o.arg) |a|
         std.fmt.bufPrint(&buf, "{s} <{s}>", .{ o.long, a }) catch o.long
     else
         o.long;
     try w.print("  {s}", .{head});
-    var pad: usize = if (head.len < 22) 22 - head.len else 1;
+    var pad: usize = if (head.len < width) width - head.len else 1;
     while (pad > 0) : (pad -= 1) try w.writeByte(' ');
     try w.print("{s}\n", .{o.help});
 }
@@ -116,6 +145,13 @@ fn writeOptLine(w: *std.Io.Writer, o: Opt) !void {
 // ---------------------------------------------------------------------------
 // man page (roff, section 1)
 // ---------------------------------------------------------------------------
+
+fn writeManOpt(w: *std.Io.Writer, o: Opt) !void {
+    if (o.arg) |a|
+        try w.print(".TP\n.B {s} <{s}>\n{s}\n", .{ o.long, a, o.help })
+    else
+        try w.print(".TP\n.B {s}\n{s}\n", .{ o.long, o.help });
+}
 
 pub fn writeMan(w: *std.Io.Writer) !void {
     try w.print(".TH HCIBRIDGE 1 \"\" \"{s} {s}\" \"User Commands\"\n", .{ program, version });
@@ -128,10 +164,9 @@ pub fn writeMan(w: *std.Io.Writer) !void {
         const spacer = if (c.args.len > 0) " " else "";
         try w.print(".TP\n.B {s}{s}{s}\n{s}\n", .{ c.name, spacer, c.args, c.summary });
         for (c.opts) |o| {
-            if (o.arg) |a|
-                try w.print(".RS\n.TP\n.B {s} <{s}>\n{s}\n.RE\n", .{ o.long, a, o.help })
-            else
-                try w.print(".RS\n.TP\n.B {s}\n{s}\n.RE\n", .{ o.long, o.help });
+            try w.writeAll(".RS\n");
+            try writeManOpt(w, o);
+            try w.writeAll(".RE\n");
         }
     }
     try w.print(".SH RUN OPTIONS\n", .{});
@@ -141,7 +176,7 @@ pub fn writeMan(w: *std.Io.Writer) !void {
         else
             try w.print(".TP\n.B {s}\n{s} (env {s})\n", .{ d.flag, d.help, d.env });
     }
-    try w.print(".TP\n.B --host <addr>\npin one board and disable discovery\n.TP\n.B --config <path>\nconfig file (default /etc/hcibridge/config; .d drop-ins)\n", .{});
+    for (run_extras) |o| try writeManOpt(w, o);
     try w.print(".SH EXAMPLES\n.TP\n{s} list\ndiscover bridges and show firmware versions\n.TP\n{s} update all firmware.bin\nupdate every discoverable bridge\n", .{ program, program });
     try w.print(".SH SEE ALSO\n.BR bluetoothctl (1)\n", .{});
 }
@@ -166,64 +201,56 @@ pub fn writeBash(w: *std.Io.Writer) !void {
     }
     try w.print("    run) COMPREPLY=( $(compgen -W \"", .{});
     for (settings.descs, 0..) |d, i| try w.print("{s}{s}", .{ if (i == 0) "" else " ", d.flag });
-    try w.print(" --host --no-discovery --config --once\" -- \"$cur\") );;\n", .{});
+    for (run_extras) |o| try w.print(" {s}", .{o.long});
+    try w.print("\" -- \"$cur\") );;\n", .{});
     try w.print("    completions) COMPREPLY=( $(compgen -W \"bash zsh fish\" -- \"$cur\") );;\n", .{});
     try w.print("  esac\n}}\ncomplete -F _{s} {s}\n", .{ program, program });
+}
+
+fn writeZshSpec(w: *std.Io.Writer, o: Opt) !void {
+    if (o.arg) |a|
+        try w.print("      '{s}[{f}]:{f}:' \\\n", .{ o.long, sq(o.help), sq(a) })
+    else
+        try w.print("      '{s}[{f}]' \\\n", .{ o.long, sq(o.help) });
 }
 
 pub fn writeZsh(w: *std.Io.Writer) !void {
     try w.print("#compdef {s}\n", .{program});
     try w.print("_{s}() {{\n  local -a cmds\n  cmds=(\n", .{program});
-    for (commands) |c| try w.print("    '{s}:{s}'\n", .{ c.name, c.summary });
+    for (commands) |c| try w.print("    '{s}:{f}'\n", .{ c.name, sq(c.summary) });
     try w.print("  )\n  if (( CURRENT == 2 )); then _describe 'command' cmds; return; fi\n", .{});
     try w.print("  case $words[2] in\n", .{});
     for (commands) |c| {
         if (c.opts.len == 0) continue;
         try w.print("    {s}) _arguments \\\n", .{c.name});
-        for (c.opts) |o| {
-            if (o.arg) |a|
-                try w.print("      '{s}[{s}]:{s}:' \\\n", .{ o.long, o.help, a })
-            else
-                try w.print("      '{s}[{s}]' \\\n", .{ o.long, o.help });
-        }
+        for (c.opts) |o| try writeZshSpec(w, o);
         try w.print("      ;;\n", .{});
     }
     try w.print("    run) _arguments \\\n", .{});
-    for (settings.descs) |d| {
-        if (d.arg) |ar|
-            try w.print("      '{s}[{s}]:{s}:' \\\n", .{ d.flag, d.help, ar })
-        else
-            try w.print("      '{s}[{s}]' \\\n", .{ d.flag, d.help });
-    }
-    try w.print("      '--host[pin one board]:addr:' '--no-discovery[disable discovery]' '--config[config file]:path:' '--once[exit after first session]' ;;\n", .{});
+    for (settings.descs) |d| try writeZshSpec(w, descOpt(d));
+    for (run_extras) |o| try writeZshSpec(w, o);
+    try w.print("      ;;\n", .{});
     try w.print("    completions) _values shell bash zsh fish;;\n", .{});
     try w.print("  esac\n}}\n_{s} \"$@\"\n", .{program});
+}
+
+fn writeFishOpt(w: *std.Io.Writer, cmd: []const u8, o: Opt) !void {
+    const long = o.long[2..];
+    const req: []const u8 = if (o.arg != null) " -r" else "";
+    try w.print("complete -c {s} -n '__fish_seen_subcommand_from {s}' -l {s}{s} -d '{f}'\n", .{ program, cmd, long, req, sq(o.help) });
 }
 
 pub fn writeFish(w: *std.Io.Writer) !void {
     try w.print("# fish completion for {s}\n", .{program});
     try w.print("complete -c {s} -f\n", .{program});
     for (commands) |c| {
-        try w.print("complete -c {s} -n '__fish_use_subcommand' -a {s} -d '{s}'\n", .{ program, c.name, c.summary });
+        try w.print("complete -c {s} -n '__fish_use_subcommand' -a {s} -d '{f}'\n", .{ program, c.name, sq(c.summary) });
     }
     for (commands) |c| {
-        for (c.opts) |o| {
-            const long = o.long[2..]; // strip --
-            if (o.arg != null)
-                try w.print("complete -c {s} -n '__fish_seen_subcommand_from {s}' -l {s} -r -d '{s}'\n", .{ program, c.name, long, o.help })
-            else
-                try w.print("complete -c {s} -n '__fish_seen_subcommand_from {s}' -l {s} -d '{s}'\n", .{ program, c.name, long, o.help });
-        }
+        for (c.opts) |o| try writeFishOpt(w, c.name, o);
     }
-    for (settings.descs) |d| {
-        const long = d.flag[2..];
-        if (d.arg != null)
-            try w.print("complete -c {s} -n '__fish_seen_subcommand_from run' -l {s} -r -d '{s}'\n", .{ program, long, d.help })
-        else
-            try w.print("complete -c {s} -n '__fish_seen_subcommand_from run' -l {s} -d '{s}'\n", .{ program, long, d.help });
-    }
-    try w.print("complete -c {s} -n '__fish_seen_subcommand_from run' -l host -r -d 'pin one board'\n", .{program});
-    try w.print("complete -c {s} -n '__fish_seen_subcommand_from run' -l no-discovery -d 'disable discovery'\n", .{program});
+    for (settings.descs) |d| try writeFishOpt(w, "run", descOpt(d));
+    for (run_extras) |o| try writeFishOpt(w, "run", o);
     try w.print("complete -c {s} -n '__fish_seen_subcommand_from completions' -a 'bash zsh fish'\n", .{program});
 }
 
@@ -236,9 +263,11 @@ pub fn writeCompletion(w: *std.Io.Writer, shell: []const u8) !void {
 
 const testing = std.testing;
 
+const generators = .{ writeHelp, writeMan, writeBash, writeZsh, writeFish };
+
 test "generators produce non-empty output" {
-    var buf: [8192]u8 = undefined;
-    inline for (.{ writeHelp, writeMan, writeBash, writeZsh, writeFish }) |gen| {
+    var buf: [16384]u8 = undefined;
+    inline for (generators) |gen| {
         var w = std.Io.Writer.fixed(&buf);
         try gen(&w);
         try testing.expect(w.end > 50);
@@ -246,9 +275,79 @@ test "generators produce non-empty output" {
 }
 
 test "every command appears in bash completion" {
-    var buf: [8192]u8 = undefined;
+    var buf: [16384]u8 = undefined;
     var w = std.Io.Writer.fixed(&buf);
     try writeBash(&w);
     const out = buf[0..w.end];
     for (commands) |c| try testing.expect(std.mem.indexOf(u8, out, c.name) != null);
+}
+
+test "run extras appear in every generator" {
+    var buf: [16384]u8 = undefined;
+    const cases = .{
+        .{ writeHelp, "--once", "--config" },
+        .{ writeMan, "--once", "--config" },
+        .{ writeBash, "--once", "--config" },
+        .{ writeZsh, "--once[", "--config[" },
+        .{ writeFish, "-l once", "-l config" },
+    };
+    inline for (cases) |case| {
+        var w = std.Io.Writer.fixed(&buf);
+        try case[0](&w);
+        const out = buf[0..w.end];
+        try testing.expect(std.mem.indexOf(u8, out, case[1]) != null);
+        try testing.expect(std.mem.indexOf(u8, out, case[2]) != null);
+    }
+}
+
+test "single quote escaping" {
+    var buf: [64]u8 = undefined;
+    var w = std.Io.Writer.fixed(&buf);
+    try w.print("'{f}'", .{sq("it's")});
+    try testing.expectEqualStrings("'it'\\''s'", buf[0..w.end]);
+}
+
+test "help strings carry no apostrophes" {
+    for (commands) |c| {
+        try testing.expect(std.mem.indexOfScalar(u8, c.summary, '\'') == null);
+        for (c.opts) |o| try testing.expect(std.mem.indexOfScalar(u8, o.help, '\'') == null);
+    }
+    for (settings.descs) |d| try testing.expect(std.mem.indexOfScalar(u8, d.help, '\'') == null);
+    for (run_extras) |o| try testing.expect(std.mem.indexOfScalar(u8, o.help, '\'') == null);
+}
+
+fn syntaxCheck(shell: []const u8, gen: *const fn (*std.Io.Writer) anyerror!void, name: []const u8) !void {
+    const io = testing.io;
+    var buf: [16384]u8 = undefined;
+    var w = std.Io.Writer.fixed(&buf);
+    try gen(&w);
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = name, .data = buf[0..w.end] });
+    var pbuf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPathFile(io, name, &pbuf);
+    const res = std.process.run(testing.allocator, io, .{ .argv = &.{ shell, "-n", pbuf[0..n] } }) catch |err| switch (err) {
+        error.FileNotFound => return error.SkipZigTest,
+        else => return err,
+    };
+    defer testing.allocator.free(res.stdout);
+    defer testing.allocator.free(res.stderr);
+    switch (res.term) {
+        .exited => |code| if (code == 0) return,
+        else => {},
+    }
+    std.debug.print("{s} -n {s} failed:\n{s}\n", .{ shell, name, res.stderr });
+    return error.SyntaxCheckFailed;
+}
+
+test "bash accepts the generated completion" {
+    try syntaxCheck("bash", writeBash, "hcibridge.bash");
+}
+
+test "zsh accepts the generated completion" {
+    try syntaxCheck("zsh", writeZsh, "_hcibridge");
+}
+
+test "fish accepts the generated completion" {
+    try syntaxCheck("fish", writeFish, "hcibridge.fish");
 }

--- a/host/systemd/hcibridge.service
+++ b/host/systemd/hcibridge.service
@@ -3,8 +3,6 @@ Description=ESP HCI bridge daemon
 Documentation=https://github.com/heppu/esp-hci-bridge
 Wants=network-online.target
 After=network-online.target
-# Start before bluetooth so bluez sees the vhci adapters on boot.
-Before=bluetooth.service
 
 [Service]
 Type=simple

--- a/packaging/APKBUILD.tmpl
+++ b/packaging/APKBUILD.tmpl
@@ -10,13 +10,9 @@ depends="bluez bluez-openrc"
 makedepends="zig"
 install=""
 subpackages="$pkgname-doc $pkgname-openrc $pkgname-bash-completion $pkgname-zsh-completion $pkgname-fish-completion"
-source="$pkgname-$pkgver.tar.gz::https://github.com/heppu/esp-hci-bridge/archive/refs/tags/v$pkgver.tar.gz
-	hcibridged.initd::https://raw.githubusercontent.com/heppu/esp-hci-bridge/v$pkgver/host/openrc/hcibridged
-	hcibridged.confd::https://raw.githubusercontent.com/heppu/esp-hci-bridge/v$pkgver/host/openrc/hcibridged.confd"
+source="$pkgname-$pkgver.tar.gz::https://github.com/heppu/esp-hci-bridge/archive/refs/tags/v$pkgver.tar.gz"
 builddir="$srcdir/esp-hci-bridge-$pkgver"
-sha512sums="SKIP  $pkgname-$pkgver.tar.gz
-SKIP  hcibridged.initd
-SKIP  hcibridged.confd"
+sha512sums="@SHA512@  $pkgname-$pkgver.tar.gz"
 
 build() {
 	zig build -Doptimize=ReleaseSafe "-Dversion=v$pkgver"
@@ -32,6 +28,6 @@ package() {
 	install -Dm644 "$builddir"/host/config/config "$pkgdir"/etc/hcibridge/config
 	install -Dm644 "$builddir"/host/config/config.d/50-example.conf "$pkgdir"/etc/hcibridge/config.d/50-example.conf
 	install -Dm644 "$builddir"/host/modules-load.conf "$pkgdir"/usr/lib/modules-load.d/hci_vhci.conf
-	install -Dm755 "$srcdir"/hcibridged.initd "$pkgdir"/etc/init.d/hcibridged
-	install -Dm644 "$srcdir"/hcibridged.confd "$pkgdir"/etc/conf.d/hcibridged
+	install -Dm755 "$builddir"/host/openrc/hcibridged "$pkgdir"/etc/init.d/hcibridged
+	install -Dm644 "$builddir"/host/openrc/hcibridged.confd "$pkgdir"/etc/conf.d/hcibridged
 }

--- a/packaging/PKGBUILD.tmpl
+++ b/packaging/PKGBUILD.tmpl
@@ -8,7 +8,7 @@ url="https://github.com/heppu/esp-hci-bridge"
 license=('MIT')
 depends=('bluez')
 makedepends=('zig')
-backup=('etc/hcibridge/config')
+backup=('etc/hcibridge/config' 'etc/hcibridge/config.d/50-example.conf' 'etc/default/hcibridge')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/heppu/esp-hci-bridge/archive/refs/tags/v$pkgver.tar.gz")
 sha256sums=('@SHA256@')
 

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -3,10 +3,16 @@
 set -eu
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 cd "$ROOT"
-VERSION=${1:-$(git describe --tags --always 2>/dev/null | sed 's/^v//' || echo 0.0.0)}
+if [ $# -ge 1 ]; then
+    GIT_VERSION="v${1#v}"
+else
+    GIT_VERSION=$(git describe --tags 2>/dev/null || echo v0.0.0)
+fi
+# rpm and pacman reject hyphens in versions, so v0.10.2-3-gabc1234 becomes 0.10.2.3.gabc1234
+VERSION=$(printf '%s' "${GIT_VERSION#v}" | tr - .)
 export VERSION
-zig build -Doptimize=ReleaseSafe "-Dversion=v$VERSION"
-zig build gen "-Dversion=v$VERSION"
+zig build -Doptimize=ReleaseSafe "-Dversion=$GIT_VERSION"
+zig build gen "-Dversion=$GIT_VERSION"
 mkdir -p dist
 cp zig-out/bin/hcibridge dist/hcibridge
 PKG_ARCH=amd64 nfpm pkg -f packaging/nfpm.yaml -p deb -t dist/

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -76,3 +76,7 @@ overrides:
     depends: [bluez, bluez-openrc]
     scripts:
       postinstall: packaging/openrc-postinstall.sh
+      preremove: packaging/openrc-preremove.sh
+    apk:
+      scripts:
+        postupgrade: packaging/openrc-postinstall.sh

--- a/packaging/openrc-postinstall.sh
+++ b/packaging/openrc-postinstall.sh
@@ -1,8 +1,13 @@
 #!/bin/sh
 set -e
 modprobe hci_vhci 2>/dev/null || true
-if command -v rc-update >/dev/null 2>&1; then
-    rc-update add hcibridged default || true
-    rc-service hcibridged restart || true
+# apk passes the new version as $1 and, on upgrade only, the old version as $2
+if command -v rc-service >/dev/null 2>&1; then
+    if [ -z "${2:-}" ]; then
+        rc-update add hcibridged default || true
+        rc-service hcibridged start || true
+    elif rc-service hcibridged status >/dev/null 2>&1; then
+        rc-service hcibridged restart || true
+    fi
 fi
 echo "hcibridge installed. Runs in discovery mode; edit /etc/hcibridge/config to configure."

--- a/packaging/openrc-preremove.sh
+++ b/packaging/openrc-preremove.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+if command -v rc-service >/dev/null 2>&1; then
+    rc-service hcibridged stop || true
+    rc-update del hcibridged default || true
+fi

--- a/packaging/systemd-postinstall.sh
+++ b/packaging/systemd-postinstall.sh
@@ -1,9 +1,19 @@
 #!/bin/sh
 set -e
 modprobe hci_vhci 2>/dev/null || true
+# rpm passes 1 on install and 2 on upgrade, deb passes configure plus the old version on upgrade
+fresh=0
+case "${1:-}" in
+    1) fresh=1 ;;
+    configure) [ -n "${2:-}" ] || fresh=1 ;;
+esac
 if command -v systemctl >/dev/null 2>&1; then
     systemctl daemon-reload || true
-    systemctl enable hcibridge.service || true
-    systemctl start hcibridge.service || true
+    if [ "$fresh" = 1 ]; then
+        systemctl enable hcibridge.service || true
+        systemctl start hcibridge.service || true
+    elif systemctl is-active --quiet hcibridge.service; then
+        systemctl restart hcibridge.service || true
+    fi
 fi
 echo "hcibridge installed. Runs in discovery mode; edit /etc/hcibridge/config to configure."

--- a/packaging/systemd-preremove.sh
+++ b/packaging/systemd-preremove.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 set -e
+# rpm passes 0 on erase and 1 on upgrade, deb passes remove or upgrade
+case "${1:-}" in
+    0|remove) ;;
+    *) exit 0 ;;
+esac
 if command -v systemctl >/dev/null 2>&1; then
     systemctl stop hcibridge.service || true
     systemctl disable hcibridge.service || true

--- a/packaging/void-template.tmpl
+++ b/packaging/void-template.tmpl
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://github.com/heppu/esp-hci-bridge"
 distfiles="https://github.com/heppu/esp-hci-bridge/archive/refs/tags/v${version}.tar.gz"
 checksum=@SHA256@
-conf_files="/etc/hcibridge/config /etc/hcibridge/config.d/50-example.conf"
+conf_files="/etc/hcibridge/config /etc/hcibridge/config.d/50-example.conf /etc/hcibridge.conf"
 
 do_build() {
 	zig build -Doptimize=ReleaseSafe "-Dversion=v${version}"
@@ -28,10 +28,12 @@ do_install() {
 	vinstall host/config/config.d/50-example.conf 644 etc/hcibridge/config.d 50-example.conf
 	vinstall host/hcibridge.conf 644 etc hcibridge.conf
 	vinstall host/modules-load.conf 644 usr/lib/modules-load.d hci_vhci.conf
-	# runit service (Void's init)
-	vmkdir etc/sv/hcibridge
 	vmkdir etc/sv/hcibridge/log
 	install -m755 host/runit/hcibridge/run "${DESTDIR}/etc/sv/hcibridge/run"
-	install -m755 host/runit/hcibridge/log/run "${DESTDIR}/etc/sv/hcibridge/log/run"
+	# Void logs through vlogger, the generic runit dir in the repo uses svlogd
+	printf '#!/bin/sh\nexec vlogger -t hcibridge\n' > "${DESTDIR}/etc/sv/hcibridge/log/run"
+	chmod 755 "${DESTDIR}/etc/sv/hcibridge/log/run"
+	ln -s /run/runit/supervise.hcibridge "${DESTDIR}/etc/sv/hcibridge/supervise"
+	ln -s /run/runit/supervise.hcibridge-log "${DESTDIR}/etc/sv/hcibridge/log/supervise"
 	vlicense LICENSE
 }

--- a/scripts/install-host-service.sh
+++ b/scripts/install-host-service.sh
@@ -4,18 +4,34 @@
 set -eu
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 
+build() {
+    cd "$ROOT"
+    zig build -Doptimize=ReleaseSafe "-Dversion=$(git describe --tags --always 2>/dev/null || echo dev)"
+}
+
+if [ "${1:-}" = --build-only ]; then
+    build
+    exit 0
+fi
+
 if [ "$(id -u)" -ne 0 ]; then
     echo "run as root: doas $0" >&2
     exit 1
 fi
 
 echo "building release binary"
-(cd "$ROOT" && zig build -Doptimize=ReleaseSafe)
+# Build as the invoking user so zig-cache and zig-out in the checkout stay theirs.
+BUILD_USER=${SUDO_USER:-${DOAS_USER:-}}
+if [ -n "$BUILD_USER" ] && [ "$BUILD_USER" != root ]; then
+    su -s /bin/sh "$BUILD_USER" -c "'$ROOT/scripts/install-host-service.sh' --build-only"
+else
+    build
+fi
 install -m 0755 "$ROOT/zig-out/bin/hcibridge" /usr/bin/hcibridge
 
-# Stop any hand-run daemon (old or new name) so it does not fight the service
-# for /dev/vhci. Only targets in-tree binaries, not the installed one.
-pkill -f "zig-out/bin/hcibridge" 2>/dev/null || true
+# Stop any hand-run in-tree daemon so it does not fight the service for /dev/vhci.
+# Anchored so it leaves hcibridge-sim and the installed binary alone.
+pkill -f '(^|/)zig-out/bin/hcibridge( |$)' 2>/dev/null || true
 
 # Shell completions and man page, generated from the binary (single source).
 BIN=/usr/bin/hcibridge

--- a/web/index.html
+++ b/web/index.html
@@ -21,7 +21,7 @@
 </head>
 <body>
 <h1>esp-hci-bridge</h1>
-<p class="sub">Olimex ESP32-POE as a remote Bluetooth controller over Ethernet.</p>
+<p class="sub">An ESP32 board as a remote Bluetooth controller over Ethernet or WiFi.</p>
 
 <div class="card">
   <p><label>Board: <select id="board"></select></label></p>
@@ -40,12 +40,13 @@
 </div>
 
 <div class="card">
-  <p>After flashing, on the PC:</p>
-<pre>modprobe hci_vhci
-hcibridged --host esp-hci-bridge
-bluetoothctl list</pre>
+  <p>After flashing, on the PC: install the <code>hcibridge</code> package from the <a href="https://github.com/heppu/esp-hci-bridge/releases/latest">latest release</a>, then claim the board.</p>
+<pre>hcibridge list                 # find the board
+sudo hcibridge claim &lt;ip&gt;      # pair it with this PC
+sudo systemctl restart hcibridge   # or: rc-service hcibridged restart</pre>
   <p>Files in this release, with flash offsets for esptool:</p>
   <table id="parts"></table>
+  <pre id="esptool"></pre>
   <p><a href="https://github.com/heppu/esp-hci-bridge">Source and releases</a></p>
 </div>
 
@@ -59,12 +60,16 @@ bluetoothctl list</pre>
       document.getElementById('date').textContent = m.built || '';
       const table = document.getElementById('parts');
       table.innerHTML = '';
+      let cmd = 'esptool --chip esp32 write_flash';
       for (const p of m.builds[0].parts) {
         const row = table.insertRow();
         const name = p.path.split('/').pop();
+        const offset = '0x' + p.offset.toString(16);
         row.insertCell().innerHTML = `<a href="${p.path}">${name}</a>`;
-        row.insertCell().textContent = '0x' + p.offset.toString(16);
+        row.insertCell().textContent = offset;
+        cmd += ` ${offset} ${name}`;
       }
+      document.getElementById('esptool').textContent = cmd;
     }).catch(() => {});
   }
   fetch('boards.json').then(r => r.json()).then(boards => {


### PR DESCRIPTION
## What
Fixes every finding from the whole-repo review (41 items across host daemon, shared protocol and CLI, firmware, and packaging), plus the test gaps it listed.

Protocol changes (board and host, firmware v0.10.3 required for the new behavior, older boards still updatable through the legacy proof path):
- Announce signatures now cover the board IP, so a captured announce cannot be replayed from another host.
- HTTP proofs include a per-boot nonce plus counter published on the status page, and a separate pre-upload proof over the content length, so proofs cannot be replayed and an upload without the key never touches flash.

Highlights:
- Host: TCP_USER_TIMEOUT, handshake deadline, pinned boards excluded from discovery, subnet parsed once and fails closed, board reappearing at a new IP replaces the old session.
- CLI and config: PSK drop-in written 0600, last key entry wins, symlinked drop-ins accepted, generated zsh and fish completions escape quotes (were broken since v0.10.0), invalid config values warn instead of silently defaulting.
- Firmware: stale fd after client swap fixed, handshake and OTA upload deadlines, rollback timer when the image never gets an IP, probe reply rate limit.
- Packaging: rpm and apk upgrade and removal scriptlets fixed, systemd unit no longer delays bluetoothd, Void log service, APKBUILD checksums, per-board bootloaders in releases, web flasher instructions.
- CI checks generated completions with bash, zsh and fish.

## Tested
- [x] `zig build test` 101 passed, 2 skipped (fish not installed locally, runs in CI)
- [x] all three firmware presets build
- [ ] hardware: needs the board claimed first, then OTA to this release