### PR TITLE
Pick up new board keys without restarting the daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,7 @@ this PC by exchanging a key, once, over the LAN:
 
 ```sh
 hcibridge list                 # find the board (KEY column says "no")
-sudo hcibridge claim <ip>      # pair it with this PC
-sudo rc-service hcibridged restart  # or: systemctl restart hcibridge
+sudo hcibridge claim <ip>      # pair it with this PC, the daemon picks it up by itself
 ```
 
 From then on the board only accepts this PC and the PC only trusts this board.

--- a/host/cli.zig
+++ b/host/cli.zig
@@ -17,7 +17,7 @@ fn envGet(ctx: ?*anyopaque, name: []const u8) ?[]const u8 {
 }
 
 /// Loads psk entries from the config (main + .d) and HCIBRIDGE_PSK. Caller deinit()s.
-fn loadKeys(io: Io, gpa: std.mem.Allocator, cfg_path: []const u8) !settings.Settings {
+pub fn loadKeys(io: Io, gpa: std.mem.Allocator, cfg_path: []const u8) !settings.Settings {
     var raw = config.loadRaw(gpa, io, cfg_path) catch |err| blk: {
         log.warn("config {s}: {s} (using defaults)", .{ cfg_path, @errorName(err) });
         break :blk config.Raw{ .arena = std.heap.ArenaAllocator.init(gpa) };
@@ -328,7 +328,7 @@ pub fn claim(io: Io, gpa: std.mem.Allocator, ip: []const u8, cfg_path: []const u
 
     if (writeFile(io, dropin, line)) {
         log.info("claimed {s} ({s}); key saved to {s}", .{ ip, info.bdaddr, dropin });
-        log.info("restart the service so it picks up the key: e.g. `rc-service hcibridged restart`", .{});
+        log.info("the running daemon picks the key up on the board's next announce", .{});
     } else |err| {
         log.warn("claimed {s} ({s}) but could not write {s}: {s}", .{ ip, info.bdaddr, dropin, @errorName(err) });
         var obuf: [256]u8 = undefined;

--- a/host/main.zig
+++ b/host/main.zig
@@ -163,18 +163,36 @@ const ClientCtx = struct {
     port: u16,
     vhci: []const u8,
     reconnect_ms: u32,
-    psk: auth.Psk,
+    psk: ?auth.Psk,
+    cfg_path: []const u8,
 };
 
 fn clientThread(ctx: *ClientCtx) void {
+    var warned = false;
     while (true) {
+        if (ctx.psk == null) {
+            // Key may appear later, when the user runs `hcibridge claim`.
+            if (cli.loadKeys(ctx.io, ctx.gpa, ctx.cfg_path)) |*fresh| {
+                defer @constCast(fresh).deinit();
+                ctx.psk = settings.lookupPsk(fresh.psk, ctx.host);
+            } else |_| {}
+            if (ctx.psk == null) {
+                if (!warned) log.err("no key for pinned board {s}: run `hcibridge claim {s}`", .{ ctx.host, ctx.host });
+                warned = true;
+                ctx.io.sleep(Io.Duration.fromMilliseconds(5000), .awake) catch {};
+                continue;
+            }
+            log.info("[{s}] key found", .{ctx.host});
+        }
         const addr = Io.net.IpAddress.resolve(ctx.io, ctx.host, ctx.port) catch |err| {
             log.warn("resolve {s}: {s}", .{ ctx.host, @errorName(err) });
             ctx.io.sleep(Io.Duration.fromMilliseconds(ctx.reconnect_ms), .awake) catch {};
             continue;
         };
-        _ = board.run(ctx.io, &addr, ctx.vhci, ctx.host, &ctx.psk, null) catch |err| {
+        _ = board.run(ctx.io, &addr, ctx.vhci, ctx.host, &ctx.psk.?, null) catch |err| {
             log.warn("[{s}] session ended: {s}", .{ ctx.host, @errorName(err) });
+            // A stale key is re-read on the next round instead of failing forever.
+            if (err == error.AuthFailed) ctx.psk = null;
         };
         ctx.io.sleep(Io.Duration.fromMilliseconds(ctx.reconnect_ms), .awake) catch {};
     }
@@ -238,18 +256,19 @@ fn runMode(io: Io, gpa: std.mem.Allocator, args: []const []const u8, env_map: *s
         const hp = splitHostPort(client, s.port);
         try pinned.append(gpa, hp.host);
         const psk = settings.lookupPsk(s.psk, hp.host) orelse
-            (if (s.psk.len == 1) settings.lookupPsk(s.psk, s.psk[0][0 .. std.mem.indexOfScalar(u8, s.psk[0], '=') orelse 0]) else null) orelse {
-            log.err("no key for pinned board {s}: run `hcibridge claim {s}`", .{ hp.host, hp.host });
-            return 2;
-        };
-        const ctx = try gpa.create(ClientCtx);
-        ctx.* = .{ .io = io, .gpa = gpa, .host = hp.host, .port = hp.port, .vhci = s.vhci, .reconnect_ms = s.reconnect_ms, .psk = psk };
+            (if (s.psk.len == 1) settings.lookupPsk(s.psk, s.psk[0][0 .. std.mem.indexOfScalar(u8, s.psk[0], '=') orelse 0]) else null);
         if (s.once and s.clients.len == 1 and !s.discovery) {
             // one-shot for scripting/tests
+            const key = psk orelse {
+                log.err("no key for pinned board {s}: run `hcibridge claim {s}`", .{ hp.host, hp.host });
+                return 2;
+            };
             const addr = try Io.net.IpAddress.resolve(io, hp.host, hp.port);
-            _ = board.run(io, &addr, s.vhci, hp.host, &psk, null) catch {};
+            _ = board.run(io, &addr, s.vhci, hp.host, &key, null) catch {};
             return 0;
         }
+        const ctx = try gpa.create(ClientCtx);
+        ctx.* = .{ .io = io, .gpa = gpa, .host = hp.host, .port = hp.port, .vhci = s.vhci, .reconnect_ms = s.reconnect_ms, .psk = psk, .cfg_path = cfg_path };
         const t = try std.Thread.spawn(.{}, clientThread, .{ctx});
         t.detach();
         log.info("pinned board {s}:{d}", .{ hp.host, hp.port });
@@ -265,6 +284,8 @@ fn runMode(io: Io, gpa: std.mem.Allocator, args: []const []const u8, env_map: *s
             .allow = s.allow,
             .deny = s.deny,
             .psk_entries = s.psk,
+            .reload_keys = cli.loadKeys,
+            .cfg_path = cfg_path,
             .pinned = pinned.items,
         });
         return 0;

--- a/host/manager.zig
+++ b/host/manager.zig
@@ -21,11 +21,41 @@ pub const Options = struct {
     /// "bdaddr=hex" entries from `hcibridge claim`. Boards without one are
     /// never attached.
     psk_entries: []const []const u8 = &.{},
+    /// Re-reads the config so a fresh `hcibridge claim` is picked up without a restart.
+    reload_keys: ?*const fn (io: Io, gpa: std.mem.Allocator, cfg_path: []const u8) anyerror!settings.Settings = null,
+    cfg_path: []const u8 = "",
     /// Hosts served by pinned client threads, their announces are ignored.
     pinned: []const []const u8 = &.{},
 };
 
 const max_warned = 256;
+
+const Keys = struct {
+    entries: []const []const u8,
+    loaded: ?settings.Settings = null,
+    last: ?Io.Clock.Timestamp = null,
+
+    /// At most one config re-read per 2 s, so a flood of unknown boards cannot
+    /// turn into a flood of disk reads.
+    fn refresh(self: *Keys, io: Io, gpa: std.mem.Allocator, opts: *const Options) bool {
+        const reload = opts.reload_keys orelse return false;
+        if (self.last) |t| if (t.untilNow(io).raw.toMilliseconds() < 2000) return false;
+        self.last = Io.Clock.Timestamp.now(io, .awake);
+        var fresh = reload(io, gpa, opts.cfg_path) catch |err| {
+            log.warn("config reload failed: {s}", .{@errorName(err)});
+            return false;
+        };
+        if (self.loaded) |*old| old.deinit();
+        self.loaded = fresh;
+        self.entries = fresh.psk;
+        _ = &fresh;
+        return true;
+    }
+
+    fn deinit(self: *Keys) void {
+        if (self.loaded) |*l| l.deinit();
+    }
+};
 
 const Cidr = struct {
     base: u32,
@@ -131,6 +161,8 @@ pub fn run(io: Io, gpa: std.mem.Allocator, opts: Options) !void {
     var active = Active.init(gpa, io);
     defer active.map.deinit();
     // Unclaimed boards are logged once each, not every 2 s.
+    var keys: Keys = .{ .entries = opts.psk_entries };
+    defer keys.deinit();
     var warned = std.StringHashMap(void).init(gpa);
     defer {
         var it = warned.keyIterator();
@@ -209,21 +241,29 @@ pub fn run(io: Io, gpa: std.mem.Allocator, opts: Options) !void {
         if (isPinned(pinned.items, from_ip)) continue;
 
         // Only boards we hold a key for, and only announces they signed.
-        const psk = settings.lookupPsk(opts.psk_entries, ann.bdaddr) orelse {
-            if (!warned.contains(ann.bdaddr)) {
-                if (warned.count() >= max_warned) {
-                    var it = warned.keyIterator();
-                    while (it.next()) |k| gpa.free(k.*);
-                    warned.clearRetainingCapacity();
+        const psk = settings.lookupPsk(keys.entries, ann.bdaddr) orelse
+            (if (keys.refresh(io, gpa, &opts)) settings.lookupPsk(keys.entries, ann.bdaddr) else null) orelse
+            {
+                if (!warned.contains(ann.bdaddr)) {
+                    if (warned.count() >= max_warned) {
+                        var it = warned.keyIterator();
+                        while (it.next()) |k| gpa.free(k.*);
+                        warned.clearRetainingCapacity();
+                    }
+                    if (gpa.dupe(u8, ann.bdaddr)) |k| warned.put(k, {}) catch gpa.free(k) else |_| {}
+                    var abuf: [24]u8 = undefined;
+                    const astr = std.fmt.bufPrint(&abuf, "{f}", .{msg.from}) catch "?";
+                    log.warn("ignoring unclaimed board {s} ({s}) at {s}: run `hcibridge claim <ip>` to pair it", .{ ann.name, ann.bdaddr, astr });
                 }
-                if (gpa.dupe(u8, ann.bdaddr)) |k| warned.put(k, {}) catch gpa.free(k) else |_| {}
-                var abuf: [24]u8 = undefined;
-                const astr = std.fmt.bufPrint(&abuf, "{f}", .{msg.from}) catch "?";
-                log.warn("ignoring unclaimed board {s} ({s}) at {s}: run `hcibridge claim <ip>` to pair it", .{ ann.name, ann.bdaddr, astr });
+                continue;
+            };
+        var verified = auth.verifyAnnounce(&psk, ann.bdaddr, ann.port, ann.name, from_ip, ann.sig);
+        if (!verified and keys.refresh(io, gpa, &opts)) {
+            if (settings.lookupPsk(keys.entries, ann.bdaddr)) |fresh| {
+                verified = auth.verifyAnnounce(&fresh, ann.bdaddr, ann.port, ann.name, from_ip, ann.sig);
             }
-            continue;
-        };
-        if (!auth.verifyAnnounce(&psk, ann.bdaddr, ann.port, ann.name, from_ip, ann.sig)) {
+        }
+        if (!verified) {
             log.warn("ignoring announce for {s} with a bad signature (spoofed, replayed, or stale key)", .{ann.bdaddr});
             continue;
         }

--- a/web/index.html
+++ b/web/index.html
@@ -42,8 +42,7 @@
 <div class="card">
   <p>After flashing, on the PC: install the <code>hcibridge</code> package from the <a href="https://github.com/heppu/esp-hci-bridge/releases/latest">latest release</a>, then claim the board.</p>
 <pre>hcibridge list                 # find the board
-sudo hcibridge claim &lt;ip&gt;      # pair it with this PC
-sudo systemctl restart hcibridge   # or: rc-service hcibridged restart</pre>
+sudo hcibridge claim &lt;ip&gt;      # pair it with this PC, the daemon picks it up by itself</pre>
   <p>Files in this release, with flash offsets for esptool:</p>
   <table id="parts"></table>
   <pre id="esptool"></pre>


### PR DESCRIPTION
## What
The manager re-reads the config (at most every 2 s) when an announce arrives for a board it has no key for or with a signature it cannot verify, so a fresh `hcibridge claim` or a re-key is live on the board's next announce. Pinned boards without a key retry the lookup every 5 s instead of aborting the daemon, and drop a stale key after an auth failure. Docs and the claim hint no longer tell the user to restart the service.

## Tested
- [x] `zig build test` 101 passed, 2 skipped
- [x] live: daemon started without a key, simulator announced and was rejected, key drop-in written, board discovered and authenticated within 5 s