### PR TITLE
Add hcibridge revoke and drop live boards whose key was removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,10 @@ sudo hcibridge claim <ip>      # pair it with this PC, the daemon picks it up by
 ```
 
 From then on the board only accepts this PC and the PC only trusts this board.
-A claimed board refuses any other claim, so nobody else on the network can take
-it over. To move a board to a different PC, erase it once over USB
+Each board gets its own key, so `sudo hcibridge revoke <bdaddr>` removes just
+that board: its key is deleted from the config and the daemon drops it on the
+spot. A claimed board refuses any other claim, so nobody else on the network can
+take it over. To move a board to a different PC, erase it once over USB
 (`esptool erase_flash`) and re-flash.
 
 ### 4. Pair your devices
@@ -97,6 +99,7 @@ rest by hand:
 | `hcibridge claim <ip>` | pair a new board with this PC |
 | `hcibridge status <ip>` | full status of one board |
 | `hcibridge update <ip\|all> <file.bin>` | update firmware over the network |
+| `hcibridge revoke <bdaddr>` | stop accepting a board (removes its key, no restart needed) |
 | `hcibridge reboot <ip>` | reboot a board |
 | `hcibridge run` | the daemon (started by the service) |
 

--- a/host/cli.zig
+++ b/host/cli.zig
@@ -253,6 +253,42 @@ pub fn update(io: Io, gpa: std.mem.Allocator, target: []const u8, path: []const 
     return if (updateOne(io, gpa, &addr, image, &keys)) 0 else 1;
 }
 
+fn dropinPath(cfg_path: []const u8, bdaddr: []const u8, buf: *[512]u8) ![]const u8 {
+    var fname: [17]u8 = undefined;
+    for (bdaddr[0..17], 0..) |c, i| fname[i] = if (c == ':') '-' else std.ascii.toLower(c);
+    return std.fmt.bufPrint(buf, "{s}.d/board-{s}.conf", .{ cfg_path, &fname });
+}
+
+/// Removes a board's key from the config. The running daemon notices on the
+/// board's next announce and drops its link. The board itself keeps thinking
+/// it is claimed, which only matters if it should pair with another PC.
+pub fn revoke(io: Io, gpa: std.mem.Allocator, bdaddr: []const u8, cfg_path: []const u8) !u8 {
+    if (bdaddr.len != 17) {
+        log.err("expected a Bluetooth address like a0:a3:b3:2f:61:1e, got {s}", .{bdaddr});
+        return 2;
+    }
+    var path_buf: [512]u8 = undefined;
+    const dropin = try dropinPath(cfg_path, bdaddr, &path_buf);
+    Io.Dir.cwd().deleteFile(io, dropin) catch |err| switch (err) {
+        error.FileNotFound => {
+            var keys = try loadKeys(io, gpa, cfg_path);
+            defer keys.deinit();
+            if (settings.lookupPsk(keys.psk, bdaddr) != null) {
+                log.err("{s} has no drop-in at {s} but a key is set elsewhere: remove the `psk = {s}=...` line from {s} or its .d files by hand", .{ bdaddr, dropin, bdaddr, cfg_path });
+                return 1;
+            }
+            log.info("{s} is not claimed on this PC, nothing to do", .{bdaddr});
+            return 0;
+        },
+        else => {
+            log.err("cannot remove {s}: {s}", .{ dropin, @errorName(err) });
+            return 1;
+        },
+    };
+    log.info("revoked {s}: removed {s}; the daemon drops the board on its next announce", .{ bdaddr, dropin });
+    return 0;
+}
+
 pub fn reboot(io: Io, gpa: std.mem.Allocator, ip: []const u8, cfg_path: []const u8) !u8 {
     const addr: Io.net.IpAddress = .{ .ip4 = Io.net.Ip4Address.parse(ip, httpc.http_port) catch {
         log.err("bad ip: {s}", .{ip});
@@ -321,10 +357,8 @@ pub fn claim(io: Io, gpa: std.mem.Allocator, ip: []const u8, cfg_path: []const u
     // Save as a drop-in: <config>.d/board-<bdaddr>.conf
     var line_buf: [128]u8 = undefined;
     const line = try std.fmt.bufPrint(&line_buf, "psk = {s}={s}\n", .{ info.bdaddr, &psk_hex });
-    var fname: [24]u8 = undefined;
-    for (info.bdaddr, 0..) |c, i| fname[i] = if (c == ':') '-' else c;
     var path_buf: [512]u8 = undefined;
-    const dropin = try std.fmt.bufPrint(&path_buf, "{s}.d/board-{s}.conf", .{ cfg_path, fname[0..17] });
+    const dropin = try dropinPath(cfg_path, info.bdaddr, &path_buf);
 
     if (writeFile(io, dropin, line)) {
         log.info("claimed {s} ({s}); key saved to {s}", .{ ip, info.bdaddr, dropin });

--- a/host/main.zig
+++ b/host/main.zig
@@ -93,6 +93,17 @@ pub fn main(init: std.process.Init) !u8 {
         };
         return cli.claim(io, gpa, ip, cfg);
     }
+    if (std.mem.eql(u8, cmd, "revoke")) {
+        const bdaddr = it.next() orelse {
+            log.err("usage: hcibridge revoke <bdaddr> [--config <path>]", .{});
+            return 2;
+        };
+        var cfg: []const u8 = cli.default_config;
+        while (it.next()) |a| if (std.mem.eql(u8, a, "--config")) {
+            cfg = it.next() orelse return error.MissingValue;
+        };
+        return cli.revoke(io, gpa, bdaddr, cfg);
+    }
     if (std.mem.eql(u8, cmd, "reboot")) {
         const ip = it.next() orelse {
             log.err("usage: hcibridge reboot <ip> [--config <path>]", .{});

--- a/host/manager.zig
+++ b/host/manager.zig
@@ -110,6 +110,18 @@ const Active = struct {
         defer self.mutex.unlock(self.io);
         _ = self.map.remove(bdaddr);
     }
+
+    /// Drops the live link of every board whose key is gone from the config.
+    fn revokeMissing(self: *Active, entries: []const []const u8) void {
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        var it = self.map.valueIterator();
+        while (it.next()) |ctx| {
+            if (settings.lookupPsk(entries, ctx.*.bdaddr) != null) continue;
+            log.info("{s} ({s}) key removed from config, revoking", .{ ctx.*.name, ctx.*.bdaddr });
+            ctx.*.link.kill(self.io);
+        }
+    }
 };
 
 const BoardCtx = struct {
@@ -240,23 +252,25 @@ pub fn run(io: Io, gpa: std.mem.Allocator, opts: Options) !void {
         };
         if (isPinned(pinned.items, from_ip)) continue;
 
+        // Every announce is a chance to notice an edited config: a fresh claim
+        // attaches, a deleted key revokes a live board.
+        if (keys.refresh(io, gpa, &opts)) active.revokeMissing(keys.entries);
+
         // Only boards we hold a key for, and only announces they signed.
-        const psk = settings.lookupPsk(keys.entries, ann.bdaddr) orelse
-            (if (keys.refresh(io, gpa, &opts)) settings.lookupPsk(keys.entries, ann.bdaddr) else null) orelse
-            {
-                if (!warned.contains(ann.bdaddr)) {
-                    if (warned.count() >= max_warned) {
-                        var it = warned.keyIterator();
-                        while (it.next()) |k| gpa.free(k.*);
-                        warned.clearRetainingCapacity();
-                    }
-                    if (gpa.dupe(u8, ann.bdaddr)) |k| warned.put(k, {}) catch gpa.free(k) else |_| {}
-                    var abuf: [24]u8 = undefined;
-                    const astr = std.fmt.bufPrint(&abuf, "{f}", .{msg.from}) catch "?";
-                    log.warn("ignoring unclaimed board {s} ({s}) at {s}: run `hcibridge claim <ip>` to pair it", .{ ann.name, ann.bdaddr, astr });
+        const psk = settings.lookupPsk(keys.entries, ann.bdaddr) orelse {
+            if (!warned.contains(ann.bdaddr)) {
+                if (warned.count() >= max_warned) {
+                    var it = warned.keyIterator();
+                    while (it.next()) |k| gpa.free(k.*);
+                    warned.clearRetainingCapacity();
                 }
-                continue;
-            };
+                if (gpa.dupe(u8, ann.bdaddr)) |k| warned.put(k, {}) catch gpa.free(k) else |_| {}
+                var abuf: [24]u8 = undefined;
+                const astr = std.fmt.bufPrint(&abuf, "{f}", .{msg.from}) catch "?";
+                log.warn("ignoring unclaimed board {s} ({s}) at {s}: run `hcibridge claim <ip>` to pair it", .{ ann.name, ann.bdaddr, astr });
+            }
+            continue;
+        };
         var verified = auth.verifyAnnounce(&psk, ann.bdaddr, ann.port, ann.name, from_ip, ann.sig);
         if (!verified and keys.refresh(io, gpa, &opts)) {
             if (settings.lookupPsk(keys.entries, ann.bdaddr)) |fresh| {

--- a/host/spec.zig
+++ b/host/spec.zig
@@ -62,6 +62,12 @@ pub const commands = [_]Cmd{
         .opts = &.{config_opt},
     },
     .{
+        .name = "revoke",
+        .summary = "stop accepting a bridge: remove its key from the config",
+        .args = "<bdaddr>",
+        .opts = &.{config_opt},
+    },
+    .{
         .name = "reboot",
         .summary = "reboot a bridge (requires its key)",
         .args = "<ip>",


### PR DESCRIPTION
## What
- `hcibridge revoke <bdaddr>` deletes the board's key drop-in (idempotent, explains when the key lives elsewhere).
- The manager now re-reads the config on every announce (rate limited to once per 2 s), not only for unknown boards, and kills the live link of any attached board whose key is gone. Revoking is effective without a restart.
- README and command table updated.

## Tested
- [x] `zig build test` 101 passed, 2 skipped
- [x] live: daemon with an attached simulated board (FIFO as vhci), `hcibridge revoke` on the scratch config, daemon logged the revoke and dropped the link within one announce interval, later announces rejected as unclaimed