### PR TITLE
Add hcibridge unclaim so a board can be handed to another PC

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,10 @@ From then on the board only accepts this PC and the PC only trusts this board.
 Each board gets its own key, so `sudo hcibridge revoke <bdaddr>` removes just
 that board: its key is deleted from the config and the daemon drops it on the
 spot. A claimed board refuses any other claim, so nobody else on the network can
-take it over. To move a board to a different PC, erase it once over USB
-(`esptool erase_flash`) and re-flash.
+take it over. To hand a board to a different PC, `sudo hcibridge unclaim <ip>`
+from the PC that owns it: the board forgets its key, reboots unclaimed, and the
+key is removed here as well. Only if that PC is gone too, erase the board once
+over USB (`esptool erase_flash`) and re-flash.
 
 ### 4. Pair your devices
 
@@ -99,7 +101,8 @@ rest by hand:
 | `hcibridge claim <ip>` | pair a new board with this PC |
 | `hcibridge status <ip>` | full status of one board |
 | `hcibridge update <ip\|all> <file.bin>` | update firmware over the network |
-| `hcibridge revoke <bdaddr>` | stop accepting a board (removes its key, no restart needed) |
+| `hcibridge revoke <bdaddr>` | stop accepting a board (removes its key here, no restart needed) |
+| `hcibridge unclaim <ip>` | release a board so another PC can claim it (needs its key) |
 | `hcibridge reboot <ip>` | reboot a board |
 | `hcibridge run` | the daemon (started by the service) |
 

--- a/firmware/main/auth.c
+++ b/firmware/main/auth.c
@@ -282,3 +282,18 @@ int auth_claim(const uint8_t peer_pub[32], uint8_t our_pub[32])
     ESP_LOGI(TAG, "board claimed, key stored");
     return ESP_OK;
 }
+
+int auth_unclaim(void)
+{
+    nvs_handle_t h;
+    if (nvs_open("bridge", NVS_READWRITE, &h) != ESP_OK) return ESP_FAIL;
+    esp_err_t err = nvs_erase_key(h, "psk");
+    if (err == ESP_ERR_NVS_NOT_FOUND) err = ESP_OK;
+    if (err == ESP_OK) err = nvs_commit(h);
+    nvs_close(h);
+    if (err != ESP_OK) return err;
+    memset(g_psk, 0, sizeof(g_psk));
+    g_claimed = false;
+    ESP_LOGW(TAG, "board unclaimed, key erased");
+    return ESP_OK;
+}

--- a/firmware/main/glue.h
+++ b/firmware/main/glue.h
@@ -21,6 +21,7 @@ bool auth_check_http(const char *method, const char *path, const uint8_t body_sh
 bool auth_check_http_pre(const char *method, const char *path, uint32_t content_len, const char *header_hex);
 bool auth_ct_equal(const uint8_t *a, const uint8_t *b, size_t n);
 int auth_claim(const uint8_t peer_pub[32], uint8_t our_pub[32]);
+int auth_unclaim(void);
 
 // Implemented in net.c
 bool net_start(void);

--- a/firmware/main/ota.c
+++ b/firmware/main/ota.c
@@ -170,6 +170,28 @@ static esp_err_t reboot_post(httpd_req_t *req)
     return ESP_OK;
 }
 
+// POST /unclaim: proves the current key, erases it, reboots unclaimed so
+// another PC can claim the board. Needs the key, so a stranger cannot do it.
+static esp_err_t unclaim_post(httpd_req_t *req)
+{
+    char auth[80], pre[80];
+    uint8_t empty_sha[32];
+    mbedtls_sha256((const unsigned char *)"", 0, empty_sha, 0);
+    if (!get_proofs(req, auth, pre, sizeof(auth)) || !auth_check_http_pre("POST", "/unclaim", 0, pre) ||
+        !auth_check_http("POST", "/unclaim", empty_sha, auth)) {
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "bad or missing X-Bridge-Auth / X-Bridge-Pre");
+        return ESP_FAIL;
+    }
+    if (auth_unclaim() != ESP_OK) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "could not erase key");
+        return ESP_FAIL;
+    }
+    httpd_resp_sendstr(req, "unclaimed, rebooting\n");
+    vTaskDelay(pdMS_TO_TICKS(300));
+    esp_restart();
+    return ESP_OK;
+}
+
 // POST /claim, body = 64 hex chars (client X25519 public key). Only while
 // unclaimed. Replies with the board's public key; both sides derive the PSK.
 static esp_err_t claim_post(httpd_req_t *req)
@@ -240,10 +262,13 @@ void ota_init(void)
     const httpd_uri_t ota_uri = { .uri = "/ota", .method = HTTP_POST, .handler = ota_post };
     const httpd_uri_t reboot_uri = { .uri = "/reboot", .method = HTTP_POST, .handler = reboot_post };
     const httpd_uri_t claim_uri = { .uri = "/claim", .method = HTTP_POST, .handler = claim_post };
+    const httpd_uri_t unclaim_uri = { .uri = "/unclaim", .method = HTTP_POST, .handler = unclaim_post };
     ESP_ERROR_CHECK(httpd_register_uri_handler(server, &status_uri));
     ESP_ERROR_CHECK(httpd_register_uri_handler(server, &ota_uri));
     ESP_ERROR_CHECK(httpd_register_uri_handler(server, &reboot_uri));
     ESP_ERROR_CHECK(httpd_register_uri_handler(server, &claim_uri));
+    ESP_ERROR_CHECK(httpd_register_uri_handler(server, &unclaim_uri));
+    ESP_ERROR_CHECK(httpd_register_uri_handler(server, &unclaim_uri));
     ESP_LOGI(TAG, "http status on /, updates via POST /ota");
 }
 

--- a/host/cli.zig
+++ b/host/cli.zig
@@ -314,6 +314,41 @@ pub fn reboot(io: Io, gpa: std.mem.Allocator, ip: []const u8, cfg_path: []const 
     return 0;
 }
 
+/// Tells a board to forget its key and reboot unclaimed, then removes the key
+/// on this side too. Requires the current key, so only the owning PC can do it.
+pub fn unclaim(io: Io, gpa: std.mem.Allocator, ip: []const u8, cfg_path: []const u8) !u8 {
+    const addr: Io.net.IpAddress = .{ .ip4 = Io.net.Ip4Address.parse(ip, httpc.http_port) catch {
+        log.err("bad ip: {s}", .{ip});
+        return 2;
+    } };
+    var keys = try loadKeys(io, gpa, cfg_path);
+    defer keys.deinit();
+    var bd: [17]u8 = undefined;
+    const info = try boardInfo(io, gpa, &addr, &bd);
+    if (info.claimed == false) {
+        log.info("{s} ({s}) is not claimed by anyone", .{ ip, info.bdaddr });
+        return revoke(io, gpa, info.bdaddr, cfg_path);
+    }
+    const psk = settings.lookupPsk(keys.psk, info.bdaddr) orelse {
+        log.err("no key for {s}: this PC did not claim it, so it cannot release it (erase the board over USB instead)", .{info.bdaddr});
+        return 1;
+    };
+    var hbuf: [160]u8 = undefined;
+    const hdr = authHeaders(&psk, "POST", "/unclaim", info.nonce, "", &hbuf);
+    var r = try httpc.postH(io, gpa, &addr, "/unclaim", "", hdr);
+    defer r.deinit(gpa);
+    if (r.status == 404) {
+        log.err("{s} runs firmware without unclaim support: run `hcibridge update {s} <esp-hci-bridge-<board>.bin>` first", .{ ip, ip });
+        return 1;
+    }
+    if (r.status != 200) {
+        log.err("unclaim rejected: HTTP {d} {s}", .{ r.status, std.mem.trim(u8, r.body, " \r\n") });
+        return 1;
+    }
+    log.info("{s} ({s}) forgot its key and is rebooting unclaimed", .{ ip, info.bdaddr });
+    return revoke(io, gpa, info.bdaddr, cfg_path);
+}
+
 /// Pairs with an unclaimed board: X25519 exchange, PSK = SHA256(shared),
 /// written as a drop-in under <config>.d/. First claim wins; re-keying needs
 /// a factory reset of the board.

--- a/host/main.zig
+++ b/host/main.zig
@@ -93,6 +93,17 @@ pub fn main(init: std.process.Init) !u8 {
         };
         return cli.claim(io, gpa, ip, cfg);
     }
+    if (std.mem.eql(u8, cmd, "unclaim")) {
+        const ip = it.next() orelse {
+            log.err("usage: hcibridge unclaim <ip> [--config <path>]", .{});
+            return 2;
+        };
+        var cfg: []const u8 = cli.default_config;
+        while (it.next()) |a| if (std.mem.eql(u8, a, "--config")) {
+            cfg = it.next() orelse return error.MissingValue;
+        };
+        return cli.unclaim(io, gpa, ip, cfg);
+    }
     if (std.mem.eql(u8, cmd, "revoke")) {
         const bdaddr = it.next() orelse {
             log.err("usage: hcibridge revoke <bdaddr> [--config <path>]", .{});

--- a/host/spec.zig
+++ b/host/spec.zig
@@ -62,6 +62,12 @@ pub const commands = [_]Cmd{
         .opts = &.{config_opt},
     },
     .{
+        .name = "unclaim",
+        .summary = "release a bridge so another PC can claim it (requires its key)",
+        .args = "<ip>",
+        .opts = &.{config_opt},
+    },
+    .{
         .name = "revoke",
         .summary = "stop accepting a bridge: remove its key from the config",
         .args = "<bdaddr>",


### PR DESCRIPTION
## What
- Board: authenticated `POST /unclaim` (same nonce proofs as `/reboot`) erases the key from NVS and reboots unclaimed.
- CLI: `hcibridge unclaim <ip>` sends it and then removes the local drop-in (same as `revoke`). Explains itself on old firmware (404), on a board this PC does not own, and on a board that is not claimed at all.
- README: revoke vs unclaim vs USB erase.

## Tested
- [x] `zig build test` 101 passed, 2 skipped
- [x] olimex firmware builds
- [ ] hardware: board must first be on this firmware