### PR TITLE
Fix v0.10.6 boot panic from a duplicate /unclaim registration

### DIFF
--- a/firmware/main/CMakeLists.txt
+++ b/firmware/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
-    SRCS "glue.c" "net.c" "ota.c" "auth.c"
+    SRCS "glue.c" "net.c" "ota.c" "auth.c" "boottrace.c"
     INCLUDE_DIRS "."
     REQUIRES bt esp_eth esp_wifi esp_netif esp_event nvs_flash lwip esp_timer esp_http_server app_update esp_app_format mbedtls
 )

--- a/firmware/main/boottrace.c
+++ b/firmware/main/boottrace.c
@@ -1,0 +1,33 @@
+#include "boottrace.h"
+#include "esp_attr.h"
+#include "esp_system.h"
+
+#define MAGIC 0x42007ace
+
+static RTC_NOINIT_ATTR uint32_t s_magic;
+static RTC_NOINIT_ATTR uint32_t s_stage;
+static uint32_t s_prev_stage;
+static int s_reset;
+
+void boottrace_init(void)
+{
+    s_reset = (int)esp_reset_reason();
+    s_prev_stage = (s_magic == MAGIC) ? s_stage : 0xffffffffu;
+    s_magic = MAGIC;
+    s_stage = 0;
+}
+
+void boottrace_mark(uint32_t stage)
+{
+    s_stage = stage;
+}
+
+uint32_t boottrace_prev_stage(void)
+{
+    return s_prev_stage;
+}
+
+int boottrace_reset_reason(void)
+{
+    return s_reset;
+}

--- a/firmware/main/boottrace.h
+++ b/firmware/main/boottrace.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <stdint.h>
+
+// Startup progress kept in RTC memory so a crash during boot can be read
+// back from the image that boots next, even after an OTA rollback.
+void boottrace_init(void);
+void boottrace_mark(uint32_t stage);
+uint32_t boottrace_prev_stage(void);
+int boottrace_reset_reason(void);

--- a/firmware/main/glue.c
+++ b/firmware/main/glue.c
@@ -1,4 +1,5 @@
 #include "glue.h"
+#include "boottrace.h"
 
 #include <string.h>
 
@@ -248,6 +249,7 @@ static void bt_init(void)
     esp_bt_controller_config_t cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
     ESP_ERROR_CHECK(esp_bt_controller_init(&cfg));
     ESP_ERROR_CHECK(esp_bt_controller_enable(ESP_BT_MODE_BTDM));
+    boottrace_mark(4);
     ESP_ERROR_CHECK(esp_vhci_host_register_callback(&vhci_cb));
 
     uint8_t mac[6];
@@ -341,6 +343,8 @@ static void discovery_task(void *arg)
 
 void app_main(void)
 {
+    boottrace_init();
+    boottrace_mark(1);
     esp_err_t err = nvs_flash_init();
     if (err == ESP_ERR_NVS_NO_FREE_PAGES || err == ESP_ERR_NVS_NEW_VERSION_FOUND) {
         ESP_ERROR_CHECK(nvs_flash_erase());
@@ -349,14 +353,20 @@ void app_main(void)
     ESP_ERROR_CHECK(err);
     ESP_ERROR_CHECK(esp_netif_init());
     ESP_ERROR_CHECK(esp_event_loop_create_default());
+    boottrace_mark(2);
     auth_init();
+    boottrace_mark(3);
 
+    boottrace_mark(5);
     if (!net_start()) {
         // Entered WiFi setup portal; do not start the bridge until configured.
         return;
     }
     bt_init();
+    boottrace_mark(6);
     bridge_start();
+    boottrace_mark(7);
     ota_init();
+    boottrace_mark(8);
     xTaskCreate(discovery_task, "discovery", 4096, NULL, 4, NULL);
 }

--- a/firmware/main/net.c
+++ b/firmware/main/net.c
@@ -1,4 +1,5 @@
 #include "glue.h"
+#include "boottrace.h"
 
 #include <string.h>
 
@@ -23,6 +24,7 @@ static volatile uint32_t g_ip4 = 0;
 
 static void on_got_ip(void *arg, esp_event_base_t base, int32_t id, void *data)
 {
+    boottrace_mark(9);
     const ip_event_got_ip_t *ev = data;
     ESP_LOGI(TAG, "ip " IPSTR " gw " IPSTR, IP2STR(&ev->ip_info.ip), IP2STR(&ev->ip_info.gw));
     g_ip4 = ev->ip_info.ip.addr;

--- a/firmware/main/ota.c
+++ b/firmware/main/ota.c
@@ -1,4 +1,5 @@
 #include "glue.h"
+#include "boottrace.h"
 
 #include <string.h>
 
@@ -22,6 +23,7 @@ static esp_timer_handle_t g_rollback_timer;
 
 static esp_err_t status_get(httpd_req_t *req)
 {
+    boottrace_mark(10);
     const esp_app_desc_t *app = esp_app_get_description();
     const esp_partition_t *running = esp_ota_get_running_partition();
     uint8_t mac[6] = {0};
@@ -36,12 +38,12 @@ static esp_err_t status_get(httpd_req_t *req)
     int n = snprintf(body, sizeof(body),
                      "{\"version\":\"%s\",\"idf\":\"%s\",\"partition\":\"%s\","
                      "\"bdaddr\":\"%02x:%02x:%02x:%02x:%02x:%02x\",\"claimed\":%s,\"nonce\":\"%s\",\"uptime_s\":%lld,"
-                     "\"free_heap\":%lu,\"stats\":%s}\n",
+                     "\"prev_stage\":%lu,\"reset\":%d,\"free_heap\":%lu,\"stats\":%s}\n",
                      app->version, app->idf_ver, running ? running->label : "?",
                      mac[0], mac[1], mac[2], mac[3], mac[4], mac[5],
                      auth_claimed() ? "true" : "false", nonce,
                      (long long)(esp_timer_get_time() / 1000000),
-                     (unsigned long)esp_get_free_heap_size(), stats);
+                     (unsigned long)boottrace_prev_stage(), boottrace_reset_reason(), (unsigned long)esp_get_free_heap_size(), stats);
     httpd_resp_set_type(req, "application/json");
     return httpd_resp_send(req, body, n);
 }
@@ -267,7 +269,6 @@ void ota_init(void)
     ESP_ERROR_CHECK(httpd_register_uri_handler(server, &ota_uri));
     ESP_ERROR_CHECK(httpd_register_uri_handler(server, &reboot_uri));
     ESP_ERROR_CHECK(httpd_register_uri_handler(server, &claim_uri));
-    ESP_ERROR_CHECK(httpd_register_uri_handler(server, &unclaim_uri));
     ESP_ERROR_CHECK(httpd_register_uri_handler(server, &unclaim_uri));
     ESP_LOGI(TAG, "http status on /, updates via POST /ota");
 }

--- a/scripts/firmware.sh
+++ b/scripts/firmware.sh
@@ -59,7 +59,7 @@ fi
 # shellcheck disable=SC2086
 exec docker run --rm $TTY_ARGS $DEVICE_ARGS \
     --user "$(id -u):$(id -g)" \
-    -e HOME=/tmp \
+    -e HOME=/tmp -e PROJECT_VER \
     -e ZIG=/project/.tools/zig-xtensa/zig \
     -v "$ROOT":/project \
     -w /project/firmware \


### PR DESCRIPTION
## What
- `ota_init` registered the `/unclaim` handler twice. The second call fails, `ESP_ERROR_CHECK` aborts, and every v0.10.6 board panics right after the bridge tasks start and rolls back. v0.10.3 to v0.10.5 images do not have the handler and are unaffected.
- Adds a boot trace: the last startup stage reached is kept in RTC memory and, with the reset reason, shown in the status JSON as `prev_stage` and `reset`. This is how the crash above was located on a board 100 m away with no serial, so it stays.
- `scripts/firmware.sh` passes `PROJECT_VER` through to the container.

## Tested
- [x] on hardware: v0.10.6-diag image reported stage 7, reset 4 (panic), reproducing the report
- [ ] on hardware: fixed image (in progress)
- [x] olimex build