### PR TITLE
Rewrite README for users, move developer material to docs/DEVELOPMENT.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Pull requests are welcome, in particular new board presets in `firmware/boards/`
 
 - `main` is protected. Open a pull request, CI (`host` and `firmware`) must pass,
   and the branch must be up to date before it can be merged (squash or rebase).
-- Run `zig fmt` and `zig build test` before pushing. See the README for building
+- Run `zig fmt` and `zig build test` before pushing. See docs/DEVELOPMENT.md for building
   the firmware in Docker.
 - Keep changes focused. Board support, host daemon, and packaging changes are
   easier to review separately.

--- a/README.md
+++ b/README.md
@@ -3,304 +3,225 @@
 [![ci](https://github.com/heppu/esp-hci-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/heppu/esp-hci-bridge/actions/workflows/ci.yml)
 [![release](https://img.shields.io/github/v/release/heppu/esp-hci-bridge)](https://github.com/heppu/esp-hci-bridge/releases/latest)
 
-Use Bluetooth devices that are nowhere near your computer.
+A remote Bluetooth adapter for Linux. A small ESP32 board on your network
+becomes a Bluetooth controller for your PC, so gamepads, keyboards, and mice
+can be in a different room from the computer they control.
 
-A tiny, cheap ESP32 board acts as a remote Bluetooth radio. Put it wherever your
-game controller, keyboard, or mouse actually is (the living room, 100 m of
-Ethernet away) and your Linux PC talks to those devices as if the Bluetooth
-adapter were built in. Pairing, input, and reconnection all work through normal
-BlueZ, because to your PC it *is* a normal Bluetooth controller.
-
-Built for playing PC games on the couch: the PC drives the TV over a long HDMI
-cable, and this puts the gamepad's Bluetooth where you are sitting instead of
-back at the machine.
+To Linux it is a normal Bluetooth adapter: you pair and connect with the usual
+tools, and everything that works with a built-in adapter works through the
+board.
 
 ```
   gamepad / keyboard / mouse
         │  Bluetooth
-   ┌────┴─────┐        HCI over your LAN         ┌──────────────────┐
-   │ ESP32    │  ───────────────────────────▶   │ your Linux PC     │
-   │ (radio)  │        (Ethernet / PoE)          │ hcibridge → BlueZ │
-   └──────────┘                                  └──────────────────┘
+   ┌────┴─────┐          your network           ┌──────────────────┐
+   │  ESP32   │  ─────────────────────────────▶ │  Linux PC        │
+   │  board   │        Ethernet or WiFi         │  hcibridge, BlueZ│
+   └──────────┘                                 └──────────────────┘
 ```
 
 ## What you need
 
-- An **ESP32 board** (original ESP32). Ethernet with PoE is the best fit,
-  but any WiFi ESP32 devkit works too. See [Supported boards](#supported-boards).
-- A **Linux PC** with BlueZ and the `hci_vhci` kernel module (standard).
-- Both on the **same network**.
+- An ESP32 board. Ethernet boards give the lowest input latency, WiFi boards
+  work too. See [supported boards](#supported-boards).
+- A Linux PC with BlueZ. Any mainstream distro qualifies.
+- Both on the same network.
 
-## Get started
+## Setup
 
 ### 1. Flash the board
 
-Open the **[web flasher](https://heppu.github.io/esp-hci-bridge/)** in Chrome,
-Chromium, or Edge, pick your board from the dropdown, plug the board into that
-computer over USB, and click Install. That is the whole firmware step.
+Open the [web flasher](https://heppu.github.io/esp-hci-bridge/) in Chrome,
+Chromium, or Edge. Pick your board, plug it in over USB, click Install.
 
-WiFi boards with no saved network start a setup hotspot on first boot: join
-`esp-hci-bridge-setup` from your phone or laptop, open `http://192.168.4.1/`,
-enter your WiFi name and password. The board reboots onto your network.
+WiFi boards start a setup hotspot on first boot. Join `esp-hci-bridge-setup`
+from a phone or laptop, open `http://192.168.4.1/`, and enter your WiFi name
+and password. The board reboots onto your network.
 
-(Prefer the terminal? The web flasher page lists every `.bin` for your board
-with its flash offset and a ready `esptool` command. Releases carry the same
-files as `esp-hci-bridge-<board>.bin`, `bootloader-<board>.bin`,
-`partition-table.bin`, and `ota_data_initial.bin`.)
+The flasher page also shows the files and offsets for `esptool` if you prefer
+the terminal.
 
-### 2. Install on your PC
+### 2. Install on the PC
 
-Grab the package for your distro and architecture from the
+Download the package for your distro from the
 [latest release](https://github.com/heppu/esp-hci-bridge/releases/latest):
 
 ```sh
-sudo dpkg -i hcibridge_*_amd64.deb                      # Debian / Ubuntu
-sudo rpm -i hcibridge-*.x86_64.rpm                      # Fedora / RHEL
+sudo dpkg -i hcibridge_*_amd64.deb                      # Debian, Ubuntu
+sudo rpm -i hcibridge-*.x86_64.rpm                      # Fedora, RHEL
 sudo apk add --allow-untrusted hcibridge_*_x86_64.apk   # Alpine
 ```
 
-Arch users have a `PKGBUILD`, Void a `void-template`, all on the release page.
-The package installs a background service that starts on boot and automatically
-finds any board on your network. Nothing else to configure.
+Arch has a `PKGBUILD` and Void a template on the release page. The package
+installs a background service that starts on boot and finds boards on its own.
 
 ### 3. Claim the board
 
-A fresh board talks to nobody until you claim it. Claiming pairs the board with
-this PC by exchanging a key, once, over the LAN:
+A fresh board talks to nobody until a PC claims it. Claiming exchanges a key
+once, over the network:
 
 ```sh
-hcibridge list                 # find the board (KEY column says "no")
-sudo hcibridge claim <ip>      # pair it with this PC, the daemon picks it up by itself
+hcibridge list                 # find the board, KEY column says unclaimed
+sudo hcibridge claim <ip>      # pair it with this PC
 ```
 
-From then on the board only accepts this PC and the PC only trusts this board.
-Each board gets its own key, so `sudo hcibridge revoke <bdaddr>` removes just
-that board: its key is deleted from the config and the daemon drops it on the
-spot. A claimed board refuses any other claim, so nobody else on the network can
-take it over. To hand a board to a different PC, `sudo hcibridge unclaim <ip>`
-from the PC that owns it: the board forgets its key, reboots unclaimed, and the
-key is removed here as well. Only if that PC is gone too, erase the board once
-over USB (`esptool erase_flash`) and re-flash.
+The service notices the new key on its own. A few seconds later the board
+appears as a Bluetooth adapter on this PC. A claimed board refuses every other
+claim, so nobody else on the network can take it.
 
 ### 4. Pair your devices
 
 ```sh
-bluetoothctl                   # scan / pair / connect, as with any adapter
+bluetoothctl                   # scan, pair, connect, as with any adapter
 ```
 
-Each board appears as its own controller, so its pairings stay with it.
+Pairings are stored on the board, so devices reconnect on their own after a
+reboot of either side. Each board is its own adapter with its own pairings.
 
-## Managing boards
+## Everyday use
 
-`hcibridge` is a single command. The service runs `hcibridge run`; you use the
-rest by hand:
+You should rarely need any of this. The service handles boards coming and going
+by itself.
 
 | command | what it does |
 |---|---|
-| `hcibridge list` | discover boards, firmware versions, whether each is claimed |
-| `hcibridge claim <ip>` | pair a new board with this PC |
-| `hcibridge status <ip>` | full status of one board |
-| `hcibridge update <ip\|all> <file.bin>` | update firmware over the network |
-| `hcibridge revoke <bdaddr>` | stop accepting a board (removes its key here, no restart needed) |
-| `hcibridge unclaim <ip>` | release a board so another PC can claim it (needs its key) |
-| `hcibridge reboot <ip>` | reboot a board |
-| `hcibridge run` | the daemon (started by the service) |
+| `hcibridge list` | show boards on the network, firmware version, claimed or not |
+| `hcibridge status <ip>` | everything one board reports, including traffic counters |
+| `sudo hcibridge claim <ip>` | pair a new board with this PC |
+| `sudo hcibridge update <ip> <file.bin>` | update a board's firmware over the network |
+| `sudo hcibridge revoke <bdaddr>` | stop trusting a board, it is dropped at once |
+| `sudo hcibridge unclaim <ip>` | release a board so another PC can claim it |
+| `sudo hcibridge reboot <ip>` | reboot a board |
 
-There is a man page (`man hcibridge`) and shell completions for bash, zsh, and
-fish, all installed by the package. Board keys are readable by root only, so
-`claim`, `revoke`, `unclaim`, `update`, and `reboot` need `sudo` or `doas`.
-`list` and `status` do not.
+Commands that use a board's key need root, `list` and `status` do not. There
+is a man page (`man hcibridge`) and completions for bash, zsh, and fish.
 
 ### Updating firmware
 
-No cable needed after the first flash. Download the new
-`esp-hci-bridge-<board>.bin` for your board from a release and:
+No cable needed after the first flash. Download the image for your board type
+from a release, then:
 
 ```sh
-hcibridge update all esp-hci-bridge-olimex-esp32-poe.bin
+sudo hcibridge update <ip> esp-hci-bridge-<board>.bin
 ```
 
-`update all` sends that one image to every board it finds, so if you run more
-than one board type, update each board by IP with its own image instead.
+Boards keep two firmware slots. If the new image fails to come up, the board
+returns to the previous one by itself. Only the PC that claimed a board can
+update it, and only with images signed by this project.
 
-Boards keep two firmware slots and roll back automatically if an update fails to
-come online. Updates are only accepted from the PC that claimed the board, and
-only for images signed with the project's release key. Anything you flash over
-USB still works, signed or not.
+### Removing a board
+
+- `sudo hcibridge revoke <bdaddr>` makes this PC stop accepting the board. The
+  board keeps its key and cannot be claimed by another PC.
+- `sudo hcibridge unclaim <ip>` makes the board forget its key and reboot
+  fresh, and removes it here too. Use this to hand a board to another PC.
+- If the PC that claimed a board is gone, erase the board over USB
+  (`esptool erase_flash`) and flash it again.
+
+### More than one board
+
+Claim each board once. After that, plugging a board in adds an adapter and
+unplugging it removes one. Put a board in every room where you want Bluetooth.
 
 ## Configuration
 
-Everything works out of the box in discovery mode. To tune it, edit
-`/etc/hcibridge/config` (drop-in fragments in `/etc/hcibridge/config.d/*.conf`
-also apply). Every setting can equally be an environment variable or a
-command-line flag; they win in that order:
+The defaults work for a home network. Settings live in `/etc/hcibridge/config`
+with drop-ins in `/etc/hcibridge/config.d/`. Every setting can also be an
+environment variable or a command line flag, and those win in that order:
 
 ```
-flag  >  environment variable  >  config file  >  built-in default
+flag  >  environment  >  config file  >  default
 ```
 
-| setting | config key | flag | environment |
-|---|---|---|---|
-| auto-discovery on/off | `discovery` | `--discovery` / `--no-discovery` | `HCIBRIDGE_DISCOVERY` |
-| accept only this IP range | `subnet` | `--subnet` | `HCIBRIDGE_SUBNET` |
-| pin specific boards | `client` | `--client` / `--host` | `HCIBRIDGE_CLIENTS` |
-| board keys (written by `claim`) | `psk` | `--psk` | `HCIBRIDGE_PSK` |
-| allow only these devices | `allow` | `--allow` | `HCIBRIDGE_ALLOW` |
-| block devices | `deny` | `--deny` | `HCIBRIDGE_DENY` |
+| setting | example | when to use it |
+|---|---|---|
+| `discovery` | `discovery = off` | you only want the boards listed under `client` |
+| `subnet` | `subnet = 192.168.1.0/24` | boards should only be accepted from one network |
+| `client` | `client = 192.168.1.50` | connect to a fixed address instead of discovering |
+| `allow`, `deny` | `deny = aa:bb:cc:dd:ee:ff` | accept or refuse boards by Bluetooth address |
 
-`allow`/`deny` take a board's Bluetooth address (the BDADDR from
-`hcibridge list`). The installed `/etc/hcibridge/config` documents every option.
+The installed config file documents every option with its flag and environment
+variable name.
+
+## Troubleshooting
+
+**`hcibridge list` shows the board but nothing appears in `bluetoothctl`.**
+Check the KEY column. An unclaimed board needs `sudo hcibridge claim <ip>`.
+If it says claimed but the service still does not attach it, the board was
+claimed by a different PC, or this PC's key was removed. `sudo hcibridge unclaim`
+from the owning PC, or erase the board over USB, then claim again.
+
+**`no key for ...: the key file is root-only`.** Run the command with `sudo`.
+
+**Update says `runs firmware without ...`.** The board is on an older firmware
+than the command needs. Update it first, that always works.
+
+**A device will not pair.** Xbox controllers need current controller firmware
+(update through an Xbox or the Xbox Accessories app on Windows). Otherwise
+pair as you would with any adapter: `bluetoothctl`, then `scan on`, `pair`,
+`trust`, `connect`.
+
+**The board keeps rebooting after an update.** It will fall back to the previous
+firmware on its own. `hcibridge status <ip>` then shows `prev_stage` (how far
+the failed image got) and `reset` (why it stopped). Include both in a bug
+report.
+
+**Lag or missed inputs.** Prefer Ethernet over WiFi for gamepads. On WiFi,
+keep the board close to the access point. `hcibridge status <ip>` shows drop
+counters, all of which should stay at zero.
+
+**Which service?** systemd: `hcibridge`. OpenRC and runit: `hcibridged`. Logs
+go to the journal on systemd and to `/var/log/hcibridged.log` on OpenRC.
 
 ## Supported boards
 
-Firmware ships as per-board presets (one image each, all in the web flasher and
-on the release page):
-
 | preset | board | network | status |
 |---|---|---|---|
-| `olimex-esp32-poe` | Olimex ESP32-POE / ESP32-POE-ISO | Ethernet, PoE | hardware-verified |
-| `wt32-eth01` | Wireless-Tag WT32-ETH01 | Ethernet | built, not yet tested on hardware |
-| `generic-wifi` | any ESP32 with WiFi (devkits, NodeMCU-32, etc.) | WiFi | built, not yet tested on hardware |
+| `olimex-esp32-poe` | Olimex ESP32-POE and ESP32-POE-ISO | Ethernet, PoE | tested on hardware |
+| `wt32-eth01` | Wireless-Tag WT32-ETH01 | Ethernet | builds, untested on hardware |
+| `generic-wifi` | any ESP32 devkit with WiFi | WiFi | builds, untested on hardware |
 
-Ethernet is the better choice for input latency; WiFi works and is fine for
-keyboards and mice, and acceptable for gamepads on a good network.
+Other Ethernet boards with a common PHY (LAN87xx, RTL8201, IP101, KSZ80xx,
+DP83848) need only a preset file. See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
 
-Other Ethernet boards: the PHY (LAN87xx, RTL8201, IP101, KSZ80xx, DP83848),
-MDC/MDIO/power pins, PHY address, and RMII clock mode are all configurable.
-Copy a preset in `firmware/boards/`, set your board's values, and build with
-`BOARD=<name> scripts/firmware.sh build`. Pull requests with new presets are
-welcome.
+> On the non-ISO Olimex ESP32-POE, unplug PoE before connecting USB. Olimex
+> warns the missing isolation can damage the PC.
 
-## More than one board
+## Security in short
 
-Discovery handles as many boards as you like at once: claim each one, and from
-then on it shows up on its own when plugged in and its adapter disappears when
-unplugged. Put one bridge in each room, or set `subnet` so the daemon only
-listens for boards on your own network.
+Every board has its own key, made when you claim it. Nothing happens without
+that key: no Bluetooth traffic, no firmware update, no reboot. Firmware images
+are signed, and the board checks the signature before booting one. The traffic
+between board and PC is authenticated but not encrypted, so anyone who can
+capture packets on your LAN can see what your devices send, the same as with
+a USB extender.
 
-### Verifying downloads
+Details in [SECURITY.md](SECURITY.md), including how to report a problem.
 
-Every release ships a `SHA256SUMS` file and a build provenance attestation
-made by GitHub Actions, so you can check that what you downloaded is what CI
-built from the tagged commit:
+## Verifying downloads
+
+Every release has a `SHA256SUMS` file and a build provenance attestation from
+GitHub Actions:
 
 ```sh
 sha256sum -c --ignore-missing SHA256SUMS
 gh attestation verify hcibridge_*_amd64.deb --repo heppu/esp-hci-bridge
 ```
 
-## Security model
+## Upgrade notes
 
-Everything a board does on the network is tied to a per-board key that only the
-board and the PC that claimed it know:
+- **From v0.10.0 to v0.10.2**: those packages shipped broken zsh and fish
+  completions, and on rpm the service ended up stopped after an upgrade. After
+  upgrading, run `sudo systemctl enable --now hcibridge` once on rpm.
+- **Boards on v0.10.0 to v0.10.5**: the first update from those versions goes
+  through automatically. After it the board uses a newer protocol and the PC
+  must run v0.10.3 or later.
+- **From v0.9.0**: boards updated onto v0.9.0 refuse further updates. Power
+  cycle the board once, then update.
 
-- The TCP link carries raw HCI, so the board demands a proof of the key before
-  a single Bluetooth packet flows, and the PC demands the same of the board
-  before it exposes a new adapter to the kernel. An unclaimed board talks to
-  nobody.
-- Discovery announcements are signed with the key, so a spoofed announcement
-  cannot get the daemon to attach to an attacker's machine.
-- Firmware updates and reboots over HTTP need a proof of the key over the
-  exact request body, and the board verifies the ECDSA signature on every image
-  before it will boot it.
+## For developers
 
-The key is set up by `hcibridge claim` with an X25519 exchange. Someone
-watching the LAN during the claim learns nothing, but they could race you to
-claim a board that is still fresh, so claim boards right after flashing. There
-is no encryption on the HCI link itself. Anyone who can sniff your wired LAN
-can see what the gamepad sends, which is the same exposure as a USB extender.
-
----
-
-## How it works
-
-The ESP32 runs only the Bluetooth *controller* (the radio and link layer) and
-forwards raw HCI packets over TCP. The PC daemon feeds those into the kernel's
-virtual HCI device (`/dev/vhci`), so BlueZ sees an ordinary local controller.
-Boards announce themselves over UDP; the daemon attaches each to its own
-adapter. The network hop adds well under a millisecond, so latency is dominated
-by the Bluetooth link itself, exactly as with a built-in adapter.
-
-## Build from source
-
-Needs [Zig](https://ziglang.org) 0.16. The PC side is one static binary with no
-libc, cross-compiled for x86_64, aarch64, and armv7.
-
-```sh
-zig build -Doptimize=ReleaseSafe   # -> zig-out/bin/hcibridge
-zig build test                     # run the test suite
-zig build release                  # static binaries for all target arches
-zig build gen                      # man page + shell completions
-```
-
-Build the distro packages locally with `packaging/build.sh` (needs `zig` and
-[`nfpm`](https://nfpm.goreleaser.com/)). The `deb`, `rpm`, and `apk` come from
-one nfpm config; `PKGBUILD`, `APKBUILD`, and the Void template build from source.
-
-To install without a package, `sudo scripts/install-host-service.sh` builds the
-binary and sets up the service for whatever init system it detects (systemd,
-OpenRC, runit, or s6).
-
-## Build the firmware
-
-Needs Docker (it pulls the ESP-IDF toolchain and a Zig with Xtensa support).
-Images are signed. Without `firmware/secure_boot_signing_key.pem` the script
-makes a throwaway development key, which means boards running release firmware
-will reject your build over OTA (flash it over USB instead, or put the release
-key in place).
-
-```sh
-scripts/firmware.sh build                              # default: olimex-esp32-poe
-BOARD=generic-wifi scripts/firmware.sh build           # another preset
-PORT=/dev/ttyUSB0 scripts/firmware.sh flash
-PORT=/dev/ttyUSB0 scripts/firmware.sh monitor
-```
-
-Each preset builds into its own `firmware/build-<board>/`. Presets live in
-`firmware/boards/*.conf`; network bring-up is in `firmware/main/net.c`.
-
-The bridge logic is Zig (`firmware/main/bridge.zig`); C is limited to ESP-IDF
-setup in `firmware/main/glue.c`. Pin assignments for the Olimex ESP32-POE are in
-`firmware/main/Kconfig.projbuild`.
-
-> On the non-ISO ESP32-POE, unplug PoE before connecting USB. Olimex warns the
-> missing isolation can otherwise damage the PC.
-
-## Repository layout
-
-| path | what |
-|---|---|
-| `common/h4.zig` | HCI H4 packet framing, shared by firmware and host |
-| `common/discovery.zig` | the UDP discovery protocol |
-| `common/auth.zig`, `firmware/main/auth.c` | the board key: handshake, signatures, claim |
-| `firmware/` | ESP32 firmware (Zig logic + ESP-IDF glue) |
-| `host/` | the `hcibridge` binary: daemon, CLI, config, settings schema |
-| `host/spec.zig`, `host/settings.zig` | single sources for the CLI and its settings |
-| `packaging/` | nfpm config and distro recipes |
-| `web/` | the browser flasher page |
-
-## Protocol
-
-Plain TCP carries HCI in H4 framing (one indicator byte, the HCI header, then
-the payload). Each connection starts with a mutual HMAC-SHA256 challenge and
-response over the board key. One client per board, and a new authenticated
-connection replaces the old one. Boards send
-`ESPHCI1 ANNOUNCE <bdaddr> <port> <name> <sig>` over UDP broadcast and answer
-probes. TCP keepalive drops a dead peer in about ten seconds.
-
-## Status
-
-> **Upgrading from v0.10.0 to v0.10.2?** Those releases shipped broken zsh and
-> fish completions and, on rpm, a preremove script that stopped and disabled the
-> service on every upgrade. After upgrading to v0.10.3 on rpm, run
-> `systemctl enable --now hcibridge` once.
->
-> **Upgrading from v0.9.0?** That release could not confirm an OTA-installed
-> image, so boards updated *onto* v0.9.0 refuse further updates and roll back
-> on reset. Power-cycle the board once (it returns to its previous firmware),
-> then update to v0.9.1 or later. Boards flashed over USB are unaffected.
-
-The bridge is complete and runs on real hardware: pairing, input, discovery,
-per-board adapters, OTA updates, and rollback all work over 100 m of Ethernet.
-Xbox Series controllers need current firmware to pair cleanly (update via a
-Windows PC or an Xbox), a known BlueZ quirk rather than a bridge limitation.
+Building the PC tool and the firmware, adding a board preset, the wire
+protocol, and the repository layout are in
+[docs/DEVELOPMENT.md](docs/DEVELOPMENT.md). Contributions are welcome, see
+[CONTRIBUTING.md](CONTRIBUTING.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ vulnerability"). You should hear back within a week.
 
 ## What is covered
 
-The threat model is documented in the README under "Security model". In short,
+The threat model is summarised in the README under "Security in short" and detailed in docs/DEVELOPMENT.md under "Protocol". In short,
 everything a board does on the network is authenticated with a per-board key
 established by `hcibridge claim`, and firmware updates over the network are
 signed with the project's release key. Reports about bypassing either of those,

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,118 @@
+# Development
+
+## How it works
+
+The ESP32 runs only the Bluetooth controller (radio and link layer) and
+forwards raw HCI packets over TCP. The PC daemon feeds them into the kernel's
+virtual HCI device (`/dev/vhci`), so BlueZ sees an ordinary local controller.
+Boards announce themselves over UDP and the daemon attaches each one to its
+own adapter. The network hop adds well under a millisecond, so latency is set
+by the Bluetooth link itself.
+
+## Build the PC tool
+
+Needs [Zig](https://ziglang.org) 0.16. The result is one static binary with no
+libc, cross-compiled for x86_64, aarch64, and armv7.
+
+```sh
+zig build -Doptimize=ReleaseSafe   # zig-out/bin/hcibridge
+zig build test                     # test suite
+zig build release                  # static binaries for all target arches
+zig build gen                      # man page and shell completions
+```
+
+Distro packages come from `packaging/build.sh` (needs `zig` and
+[`nfpm`](https://nfpm.goreleaser.com/)). One nfpm config produces deb, rpm,
+and apk. `PKGBUILD`, `APKBUILD`, and the Void template build from source.
+
+To install without a package, `sudo scripts/install-host-service.sh` builds the
+binary and sets up the service for the init system it detects (systemd,
+OpenRC, runit, or s6).
+
+## Build the firmware
+
+Needs Docker. The script pulls the ESP-IDF toolchain and a Zig with Xtensa
+support.
+
+```sh
+scripts/firmware.sh build                              # default preset olimex-esp32-poe
+BOARD=generic-wifi scripts/firmware.sh build           # another preset
+PORT=/dev/ttyUSB0 scripts/firmware.sh flash
+PORT=/dev/ttyUSB0 scripts/firmware.sh monitor
+PROJECT_VER=v1.2.3-test scripts/firmware.sh build      # custom version string
+```
+
+Each preset builds into `firmware/build-<board>/`. Images are signed. Without
+`firmware/secure_boot_signing_key.pem` the script generates a throwaway
+development key, and boards running release firmware will reject that image
+over the network. Flash such builds over USB, or put the release key in place.
+
+The bridge logic is Zig (`firmware/main/bridge.zig`). C is limited to ESP-IDF
+setup: `glue.c` (startup, sockets, discovery), `net.c` (Ethernet and WiFi),
+`ota.c` (HTTP status, update, claim), `auth.c` (board key). Pin defaults are in
+`firmware/main/Kconfig.projbuild`.
+
+### Boot trace
+
+Startup progress is kept in RTC memory, which survives a reset. After a crash
+the next image reports it in the status JSON as `prev_stage` and `reset`
+(an `esp_reset_reason` value). Stages: 1 boot, 2 to 3 key init, 4 Bluetooth
+controller up, 5 network start, 6 to 7 bridge tasks, 8 HTTP server up, 9 got
+an IP address, 10 first HTTP request served. This is the way to debug a board
+that has no serial cable attached.
+
+### Adding a board preset
+
+Copy a file in `firmware/boards/`, set the PHY (LAN87xx, RTL8201, IP101,
+KSZ80xx, DP83848), MDC/MDIO/power pins, PHY address, and RMII clock mode, and
+build with `BOARD=<name>`. Add the preset to the matrix in
+`.github/workflows/release.yml` and to `scripts/make-site.sh` so the flasher
+and release carry it.
+
+## Protocol
+
+TCP carries HCI in H4 framing: one indicator byte, the HCI header, then the
+payload. Every connection starts with a mutual HMAC-SHA256 challenge and
+response over the board key. One client per board, a new authenticated
+connection replaces the old one. A dead peer is dropped after about ten
+seconds by TCP keepalive and user timeout.
+
+Boards broadcast `ESPHCI1 ANNOUNCE <bdaddr> <port> <name> <sig>` over UDP and
+answer probes. The signature covers the board's own IP address, so a captured
+announce cannot be replayed from elsewhere.
+
+HTTP requests that change the board (`/ota`, `/reboot`, `/unclaim`) carry two
+proofs computed with the key over a nonce the board publishes on `GET /`. The
+nonce changes after every accepted request, so a captured request cannot be
+replayed. `/ota` checks the first proof, over the content length, before
+touching flash, and the second, over the body hash, before activating the
+image.
+
+The key itself comes from an X25519 exchange at claim time:
+`PSK = SHA256(shared secret)`. The Zig side is in `common/auth.zig`, the C
+side in `firmware/main/auth.c`, and `common/auth.zig` carries fixed test
+vectors that both must match.
+
+## Repository layout
+
+| path | what |
+|---|---|
+| `common/h4.zig` | HCI H4 packet framing, shared by firmware and host |
+| `common/discovery.zig` | the UDP discovery protocol |
+| `common/auth.zig` | board key: handshake, signatures, HTTP proofs, claim |
+| `firmware/` | ESP32 firmware, Zig logic plus ESP-IDF glue |
+| `host/` | the `hcibridge` binary: daemon, CLI, config |
+| `host/spec.zig`, `host/settings.zig` | single sources for the CLI, help, man page, completions, and settings |
+| `host/sim.zig` | a simulated board used by the integration tests |
+| `packaging/` | nfpm config, distro recipes, service scriptlets |
+| `web/` | the browser flasher page |
+| `scripts/` | firmware build wrapper, site assembly, service installer |
+
+## Releasing
+
+Push a `v*` tag on a commit that is on `main`. The workflow refuses tags that
+are not, builds every preset with the release signing key from the
+`FIRMWARE_SIGNING_KEY` secret, packages the PC tool, publishes `SHA256SUMS` and
+provenance attestations, and deploys the flasher page. Losing the signing key
+means no board can be updated over the network again, so keep a copy outside
+CI.


### PR DESCRIPTION
README now leads with what the tool does, setup in four steps, everyday commands, removing boards, configuration by use case, and a troubleshooting section built from real problems hit so far. Personal context and developer material are gone from it. Build instructions, the boot trace, board presets, the protocol, repository layout, and release steps live in docs/DEVELOPMENT.md.