### PR TITLE
Speed up CI: ccache and toolchain caches, skip firmware build when nothing it depends on changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       firmware: ${{ steps.f.outputs.firmware }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad # v3
         id: f
         with:
@@ -67,10 +67,25 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: espressif/idf:v5.5.5
+    env:
+      IDF_CCACHE_ENABLE: "1"
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: .tools/zig-xtensa
+          key: zig-xtensa-0.16.0-xtensa
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: .ccache
+          key: ccache-${{ hashFiles('firmware/sdkconfig.defaults', 'firmware/boards/**') }}-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ hashFiles('firmware/sdkconfig.defaults', 'firmware/boards/**') }}-
+            ccache-
       - name: Fetch Espressif Zig
         run: |
+          [ -x .tools/zig-xtensa/zig ] && exit 0
           mkdir -p .tools/zig-xtensa
           curl -sSL https://github.com/kassane/zig-espressif-bootstrap/releases/download/0.16.0-xtensa/zig-relsafe-x86_64-linux-musl-baseline.tar.xz \
             | tar -xJ -C .tools/zig-xtensa --strip-components=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      firmware: ${{ steps.f.outputs.firmware }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad # v3
+        id: f
+        with:
+          filters: |
+            firmware:
+              - 'firmware/**'
+              - 'common/**'
+              - 'scripts/firmware.sh'
+              - '.github/workflows/ci.yml'
+
   host:
     runs-on: ubuntu-latest
     steps:
@@ -20,6 +36,13 @@ jobs:
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.16.0
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cache/zig
+          key: zig-cache-${{ hashFiles('build.zig', 'build.zig.zon') }}-${{ github.sha }}
+          restore-keys: |
+            zig-cache-${{ hashFiles('build.zig', 'build.zig.zon') }}-
+            zig-cache-
       - run: zig fmt --check build.zig common host firmware/main
       - run: zig build test --summary all
       - run: zig build -Doptimize=ReleaseSafe
@@ -72,6 +95,7 @@ jobs:
               -DSDKCONFIG_DEFAULTS="sdkconfig.defaults;boards/$b.conf" build
             espsecure.py verify_signature --version 1 --keyfile secure_boot_signing_key.pem "build-$b/esp-hci-bridge.bin"
           done
+          ccache -s | head -6
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: firmware

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,25 @@ jobs:
     strategy:
       matrix:
         board: [olimex-esp32-poe, wt32-eth01, generic-wifi]
+    env:
+      IDF_CCACHE_ENABLE: "1"
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: .tools/zig-xtensa
+          key: zig-xtensa-0.16.0-xtensa
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: .ccache
+          key: ccache-${{ hashFiles('firmware/sdkconfig.defaults', 'firmware/boards/**') }}-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ hashFiles('firmware/sdkconfig.defaults', 'firmware/boards/**') }}-
+            ccache-
       - name: Fetch Espressif Zig
         run: |
+          [ -x .tools/zig-xtensa/zig ] && exit 0
           mkdir -p .tools/zig-xtensa
           curl -sSL https://github.com/kassane/zig-espressif-bootstrap/releases/download/0.16.0-xtensa/zig-relsafe-x86_64-linux-musl-baseline.tar.xz \
             | tar -xJ -C .tools/zig-xtensa --strip-components=1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,13 @@ jobs:
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.16.0
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cache/zig
+          key: zig-cache-${{ hashFiles('build.zig', 'build.zig.zon') }}-${{ github.sha }}
+          restore-keys: |
+            zig-cache-${{ hashFiles('build.zig', 'build.zig.zon') }}-
+            zig-cache-
       - run: zig build test --summary all
       - run: zig build release -Dversion="${GITHUB_REF_NAME}"
       - name: Generate man page and completions

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ _site/
 dist/
 firmware/secure_boot_signing_key.pem
 dist-*/
+.ccache/


### PR DESCRIPTION
- The firmware job only runs when firmware/, common/, the firmware build script, or the workflow itself changed. A skipped job satisfies the required check, so docs and packaging PRs no longer wait six minutes for an ESP-IDF build.
- ccache (already in the IDF image) now persists between runs via actions/cache, keyed on sdkconfig and board presets, so a real firmware change rebuilds only what it touches.
- The Xtensa Zig tarball and the host Zig cache are cached too.
- Same caches in the release workflow.