### PR TITLE
Name repository apks the way apk fetches them

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,8 @@ jobs:
           cp packaging/keys/$KEY.rsa.pub repo/alpine/
           for arch in x86_64 aarch64 armv7; do
             mkdir -p "repo/alpine/$arch"
-            cp "out/hcibridge_${VER}_${arch}.apk" "repo/alpine/$arch/"
+            # apk fetches <name>-<version>.apk, whatever the file was called at build time
+            cp "out/hcibridge_${VER}_${arch}.apk" "repo/alpine/$arch/hcibridge-${VER}.apk"
           done
           docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp -v "$PWD/repo/alpine:/r" -v "$PWD/packaging/keys:/keys:ro" alpine:3.22 \
             sh -c 'for d in /r/*/; do cd "$d" && apk index --keys-dir /keys -o unsigned.tar.gz *.apk; done'


### PR DESCRIPTION
apk downloads `<name>-<version>.apk` from the repository, and the index does not carry file names, so the nfpm output must be renamed when copied into the repo. Found on the first real `apk upgrade`: index trusted, package 404. The local test had been a simulate, which never fetches.