### PR TITLE
Give the CLI real progress, consistent output, and errors that say what to do

### DIFF
--- a/host/cli.zig
+++ b/host/cli.zig
@@ -6,6 +6,7 @@ const disc = @import("discovery");
 const auth = @import("auth");
 const httpc = @import("httpc.zig");
 const release = @import("release.zig");
+const ui = @import("ui.zig");
 const config = @import("config.zig");
 const settings = @import("settings.zig");
 const X25519 = std.crypto.dh.X25519;
@@ -174,9 +175,10 @@ pub fn list(io: Io, gpa: std.mem.Allocator, discovery_port: u16, window_ms: u32)
 }
 
 pub fn status(io: Io, gpa: std.mem.Allocator, ip: []const u8) !u8 {
+    var u = ui.Ui.init(io);
     const addr: Io.net.IpAddress = .{ .ip4 = try Io.net.Ip4Address.parse(ip, 80) };
     var r = httpc.get(io, gpa, &addr, "/") catch |err| {
-        log.err("cannot reach {s}: {s}", .{ ip, @errorName(err) });
+        u.fail("cannot reach {s}: {s}", .{ ip, @errorName(err) }, "", .{});
         return 1;
     };
     defer r.deinit(gpa);
@@ -219,35 +221,75 @@ fn authHeaders(psk: *const auth.Psk, method: []const u8, path: []const u8, nonce
     return std.fmt.bufPrint(out, "X-Bridge-Auth: {s}", .{&mac}) catch unreachable;
 }
 
-fn updateOne(io: Io, gpa: std.mem.Allocator, addr: *const Io.net.IpAddress, image: []const u8, keys: *const settings.Settings) bool {
+fn onUpload(ctx: *anyopaque, sent: usize) void {
+    const bar: *ui.Progress = @ptrCast(@alignCast(ctx));
+    bar.update(sent);
+}
+
+fn updateOne(io: Io, gpa: std.mem.Allocator, u: *ui.Ui, addr: *const Io.net.IpAddress, image: []const u8, keys: *const settings.Settings) bool {
     var bd: [17]u8 = undefined;
+    var ipb: [48]u8 = undefined;
+    const ip = ui.ipOf(addr, &ipb);
+    u.step("Board {s}", .{ip});
     const info = boardInfo(io, gpa, addr, &bd) catch |err| {
-        log.err("cannot query {f}: {s}", .{ addr.*, @errorName(err) });
+        u.fail("board {s} did not answer: {s}", .{ ip, ui.explain(err) }, "is it powered and on this network? `hcibridge list` shows what is visible", .{});
         return false;
     };
+    u.done("{s}, {s}, running {s}", .{ info.bdaddr, info.board() orelse "unknown board type", info.version() });
     // Firmware before v0.10 reports no claim state and takes unauthenticated
     // uploads, which is the only way to move such a board onto keyed firmware.
     var hbuf: [160]u8 = undefined;
     var hdr: ?[]const u8 = null;
     if (info.claimed != null) {
         const psk = settings.lookupPsk(keys.psk, info.bdaddr) orelse {
-            log.err("no key for {s} ({f}): {s}", .{ info.bdaddr, addr.*, noKeyHint() });
+            u.fail("no key for {s}", .{info.bdaddr}, "{s}", .{noKeyHint()});
             return false;
         };
         hdr = authHeaders(&psk, "POST", "/ota", info.nonce, image, &hbuf);
-    } else log.warn("{f} runs pre-key firmware, sending unauthenticated update", .{addr.*});
-    log.info("updating {f} ({s}), {d} bytes", .{ addr.*, info.bdaddr, image.len });
-    var r = httpc.postH(io, gpa, addr, "/ota", image, hdr) catch |err| {
-        log.err("  ota failed: {s}", .{@errorName(err)});
+    } else u.warn("{s} runs firmware from before keys existed, sending the update unauthenticated", .{ip});
+    var bar = u.progress("Uploading to {s}", .{ip}, image.len);
+    var r = httpc.postProgress(io, gpa, addr, "/ota", image, hdr, onUpload, @ptrCast(&bar)) catch |err| {
+        bar.finish(0);
+        u.fail("upload to {s} failed: {s}", .{ ip, ui.explain(err) }, "", .{});
         return false;
     };
     defer r.deinit(gpa);
+    bar.finish(image.len);
     if (r.status != 200) {
-        log.err("  ota rejected: HTTP {d} {s}", .{ r.status, std.mem.trim(u8, r.body, " \r\n") });
+        const hint: []const u8 = switch (r.status) {
+            401, 403 => "the key on this PC does not match the board, run `hcibridge claim` again or check /etc/hcibridge/config.d",
+            413 => "the image is larger than the board's firmware partition",
+            else => "",
+        };
+        u.fail("board {s} rejected the image: HTTP {d} {s}", .{ ip, r.status, std.mem.trim(u8, r.body, " \r\n") }, "{s}", .{hint});
         return false;
     }
-    log.info("  sent, board rebooting", .{});
+    u.info("Board accepted the image and is rebooting", .{});
+    waitForBoard(io, gpa, u, addr, info.version());
     return true;
+}
+
+/// Polls the board after an OTA until it answers again, then says what it runs.
+fn waitForBoard(io: Io, gpa: std.mem.Allocator, u: *ui.Ui, addr: *const Io.net.IpAddress, old_version: []const u8) void {
+    u.step("Waiting for it to come back", .{});
+    const start = Io.Clock.Timestamp.now(io, .awake);
+    io.sleep(Io.Duration.fromMilliseconds(3000), .awake) catch {};
+    while (start.untilNow(io).raw.toMilliseconds() < 90_000) {
+        var bd: [17]u8 = undefined;
+        if (boardInfo(io, gpa, addr, &bd)) |info| {
+            const secs = @divTrunc(start.untilNow(io).raw.toMilliseconds(), 1000);
+            u.done("up after {d} s, running {s}", .{ secs, info.version() });
+            if (std.mem.eql(u8, info.version(), old_version)) {
+                u.warn("same version as before, the new image may have failed to boot and rolled back", .{});
+                var ipb: [48]u8 = undefined;
+                u.info("  `hcibridge status {s}` shows prev_stage (how far it got) and reset (why it stopped)", .{ui.ipOf(addr, &ipb)});
+            }
+            return;
+        } else |_| {}
+        io.sleep(Io.Duration.fromMilliseconds(1000), .awake) catch {};
+    }
+    u.done("no answer after 90 s", .{});
+    u.warn("the board did not come back yet, check `hcibridge list` in a minute", .{});
 }
 
 /// Images for the latest release, fetched once per board preset.
@@ -257,11 +299,15 @@ const LatestImages = struct {
     cache: std.StringHashMap([]u8),
     gpa: std.mem.Allocator,
 
-    fn init(io: Io, gpa: std.mem.Allocator) !LatestImages {
+    fn init(io: Io, gpa: std.mem.Allocator, u: *ui.Ui) !LatestImages {
         var client: std.http.Client = .{ .allocator = gpa, .io = io };
         errdefer client.deinit();
-        log.info("checking the latest release of {s}", .{release.repo});
-        const rel = try release.latest(&client, gpa);
+        u.step("Checking the latest release of {s}", .{release.repo});
+        const rel = release.latest(&client, gpa) catch |err| {
+            u.done("failed", .{});
+            return err;
+        };
+        u.done("{s}", .{rel.tag});
         return .{ .client = client, .rel = rel, .cache = std.StringHashMap([]u8).init(gpa), .gpa = gpa };
     }
 
@@ -276,11 +322,11 @@ const LatestImages = struct {
         self.client.deinit();
     }
 
-    fn image(self: *LatestImages, board: []const u8) ![]const u8 {
+    fn image(self: *LatestImages, u: *ui.Ui, board: []const u8) ![]const u8 {
         if (self.cache.get(board)) |img| return img;
-        log.info("downloading {s} firmware for {s}", .{ self.rel.tag, board });
-        const img = try self.rel.image(&self.client, self.gpa, board);
+        const img = try self.rel.image(&self.client, self.gpa, board, u);
         errdefer self.gpa.free(img);
+        u.info("Checksum ok", .{});
         const key = try self.gpa.dupe(u8, board);
         errdefer self.gpa.free(key);
         try self.cache.put(key, img);
@@ -290,26 +336,38 @@ const LatestImages = struct {
 
 /// Picks the image for one board: the given file, or the latest release for
 /// the board's preset. Returns null when the board is already on that release.
-fn imageFor(io: Io, gpa: std.mem.Allocator, addr: *const Io.net.IpAddress, file_image: ?[]const u8, latest_images: *?LatestImages, board_override: ?[]const u8) !?[]const u8 {
+fn imageFor(io: Io, gpa: std.mem.Allocator, u: *ui.Ui, addr: *const Io.net.IpAddress, file_image: ?[]const u8, latest_images: *?LatestImages, board_override: ?[]const u8) !?[]const u8 {
     if (file_image) |img| return img;
     var bd: [17]u8 = undefined;
-    const info = try boardInfo(io, gpa, addr, &bd);
-    const board = board_override orelse info.board() orelse {
-        log.err("{f} runs firmware that does not say which board it is: pass --board <preset> or a file", .{addr.*});
-        return error.UnknownBoard;
+    var ipb: [48]u8 = undefined;
+    const ip = ui.ipOf(addr, &ipb);
+    const info = boardInfo(io, gpa, addr, &bd) catch |err| {
+        u.fail("board {s} did not answer: {s}", .{ ip, ui.explain(err) }, "is it powered and on this network? `hcibridge list` shows what is visible", .{});
+        return error.Reported;
     };
-    if (latest_images.* == null) latest_images.* = try LatestImages.init(io, gpa);
+    const board = board_override orelse info.board() orelse {
+        u.fail("{s} runs firmware that does not say which board it is", .{ip}, "pass --board <preset> (olimex-esp32-poe, wt32-eth01, generic-wifi) or a firmware file", .{});
+        return error.Reported;
+    };
+    if (latest_images.* == null) latest_images.* = LatestImages.init(io, gpa, u) catch |err| {
+        u.fail("could not reach the release page: {s}", .{ui.explain(err)}, "check the network, or pass a firmware file downloaded by other means", .{});
+        return error.Reported;
+    };
     const li = &latest_images.*.?;
     if (std.mem.eql(u8, info.version(), li.rel.tag)) {
-        log.info("{f} ({s}) already runs {s}", .{ addr.*, board, li.rel.tag });
+        u.info("{s} ({s}) already runs {s}, nothing to do", .{ ip, board, li.rel.tag });
         return null;
     }
-    return try li.image(board);
+    return li.image(u, board) catch |err| {
+        u.fail("could not fetch the {s} image for {s}: {s}", .{ li.rel.tag, board, ui.explain(err) }, "", .{});
+        return error.Reported;
+    };
 }
 
 pub fn update(io: Io, gpa: std.mem.Allocator, target: []const u8, path: ?[]const u8, board_override: ?[]const u8, discovery_port: u16, cfg_path: []const u8) !u8 {
+    var u = ui.Ui.init(io);
     const file_image: ?[]const u8 = if (path) |p| readFile(io, gpa, p) catch |err| {
-        log.err("cannot read {s}: {s}", .{ p, @errorName(err) });
+        u.fail("cannot read {s}: {s}", .{ p, ui.explain(err) }, "", .{});
         return 1;
     } else null;
     defer if (file_image) |img| gpa.free(img);
@@ -319,38 +377,34 @@ pub fn update(io: Io, gpa: std.mem.Allocator, target: []const u8, path: ?[]const
     defer keys.deinit();
 
     if (std.mem.eql(u8, target, "all")) {
+        u.step("Looking for boards", .{});
         const bridges = try collect(io, gpa, discovery_port, 2500);
         defer gpa.free(bridges);
+        u.done("{d} found", .{bridges.len});
         if (bridges.len == 0) {
-            log.err("no bridges found to update", .{});
+            u.fail("no boards answered on the network", .{}, "`hcibridge list` uses the same discovery, boards must be on this LAN and powered", .{});
             return 1;
         }
         var ok: usize = 0;
         for (bridges) |*b| {
             var a = b.addr;
             a.setPort(80);
-            const img = imageFor(io, gpa, &a, file_image, &latest_images, board_override) catch |err| {
-                log.err("{f}: {s}", .{ a, @errorName(err) });
-                continue;
-            } orelse {
+            const img = (imageFor(io, gpa, &u, &a, file_image, &latest_images, board_override) catch continue) orelse {
                 ok += 1;
                 continue;
             };
-            if (updateOne(io, gpa, &a, img, &keys)) ok += 1;
+            if (updateOne(io, gpa, &u, &a, img, &keys)) ok += 1;
         }
-        log.info("{d}/{d} bridges up to date", .{ ok, bridges.len });
+        u.info("{d} of {d} boards up to date", .{ ok, bridges.len });
         return if (ok == bridges.len) 0 else 1;
     }
 
     const addr: Io.net.IpAddress = .{ .ip4 = Io.net.Ip4Address.parse(target, 80) catch {
-        log.err("target must be an IPv4 address or 'all'", .{});
+        u.fail("{s} is not an IPv4 address", .{target}, "give a board address from `hcibridge list`, or `all`", .{});
         return 2;
     } };
-    const img = imageFor(io, gpa, &addr, file_image, &latest_images, board_override) catch |err| {
-        log.err("{f}: {s}", .{ addr, @errorName(err) });
-        return 1;
-    } orelse return 0;
-    return if (updateOne(io, gpa, &addr, img, &keys)) 0 else 1;
+    const img = (imageFor(io, gpa, &u, &addr, file_image, &latest_images, board_override) catch return 1) orelse return 0;
+    return if (updateOne(io, gpa, &u, &addr, img, &keys)) 0 else 1;
 }
 
 fn dropinPath(cfg_path: []const u8, bdaddr: []const u8, buf: *[512]u8) ![]const u8 {
@@ -363,8 +417,9 @@ fn dropinPath(cfg_path: []const u8, bdaddr: []const u8, buf: *[512]u8) ![]const 
 /// board's next announce and drops its link. The board itself keeps thinking
 /// it is claimed, which only matters if it should pair with another PC.
 pub fn revoke(io: Io, gpa: std.mem.Allocator, bdaddr: []const u8, cfg_path: []const u8) !u8 {
+    var u = ui.Ui.init(io);
     if (bdaddr.len != 17) {
-        log.err("expected a Bluetooth address like a0:a3:b3:2f:61:1e, got {s}", .{bdaddr});
+        u.fail("expected a Bluetooth address like a0:a3:b3:2f:61:1e, got {s}", .{bdaddr}, "", .{});
         return 2;
     }
     var path_buf: [512]u8 = undefined;
@@ -374,24 +429,25 @@ pub fn revoke(io: Io, gpa: std.mem.Allocator, bdaddr: []const u8, cfg_path: []co
             var keys = try loadKeys(io, gpa, cfg_path);
             defer keys.deinit();
             if (settings.lookupPsk(keys.psk, bdaddr) != null) {
-                log.err("{s} has no drop-in at {s} but a key is set elsewhere: remove the `psk = {s}=...` line from {s} or its .d files by hand", .{ bdaddr, dropin, bdaddr, cfg_path });
+                u.fail("{s} has no drop-in at {s} but a key is set elsewhere: remove the `psk = {s}=...` line from {s} or its .d files by hand", .{ bdaddr, dropin, bdaddr, cfg_path }, "", .{});
                 return 1;
             }
-            log.info("{s} is not claimed on this PC, nothing to do", .{bdaddr});
+            u.info("{s} is not claimed on this PC, nothing to do", .{bdaddr});
             return 0;
         },
         else => {
-            log.err("cannot remove {s}: {s}", .{ dropin, @errorName(err) });
+            u.fail("cannot remove {s}: {s}", .{ dropin, @errorName(err) }, "", .{});
             return 1;
         },
     };
-    log.info("revoked {s}: removed {s}; the daemon drops the board on its next announce", .{ bdaddr, dropin });
+    u.info("revoked {s}: removed {s}; the daemon drops the board on its next announce", .{ bdaddr, dropin });
     return 0;
 }
 
 pub fn reboot(io: Io, gpa: std.mem.Allocator, ip: []const u8, cfg_path: []const u8) !u8 {
+    var u = ui.Ui.init(io);
     const addr: Io.net.IpAddress = .{ .ip4 = Io.net.Ip4Address.parse(ip, httpc.http_port) catch {
-        log.err("bad ip: {s}", .{ip});
+        u.fail("bad ip: {s}", .{ip}, "", .{});
         return 2;
     } };
     var keys = try loadKeys(io, gpa, cfg_path);
@@ -399,7 +455,7 @@ pub fn reboot(io: Io, gpa: std.mem.Allocator, ip: []const u8, cfg_path: []const 
     var bd: [17]u8 = undefined;
     const info = try boardInfo(io, gpa, &addr, &bd);
     const psk = settings.lookupPsk(keys.psk, info.bdaddr) orelse {
-        log.err("no key for {s}: {s}", .{ info.bdaddr, noKeyHint() });
+        u.fail("no key for {s}", .{info.bdaddr}, "{s}", .{noKeyHint()});
         return 1;
     };
     var hbuf: [160]u8 = undefined;
@@ -407,18 +463,19 @@ pub fn reboot(io: Io, gpa: std.mem.Allocator, ip: []const u8, cfg_path: []const 
     var r = try httpc.postH(io, gpa, &addr, "/reboot", "", hdr);
     defer r.deinit(gpa);
     if (r.status != 200) {
-        log.err("reboot rejected: HTTP {d}", .{r.status});
+        u.fail("reboot rejected: HTTP {d}", .{r.status}, "", .{});
         return 1;
     }
-    log.info("{s} rebooting", .{ip});
+    u.info("{s} rebooting", .{ip});
     return 0;
 }
 
 /// Tells a board to forget its key and reboot unclaimed, then removes the key
 /// on this side too. Requires the current key, so only the owning PC can do it.
 pub fn unclaim(io: Io, gpa: std.mem.Allocator, ip: []const u8, cfg_path: []const u8) !u8 {
+    var u = ui.Ui.init(io);
     const addr: Io.net.IpAddress = .{ .ip4 = Io.net.Ip4Address.parse(ip, httpc.http_port) catch {
-        log.err("bad ip: {s}", .{ip});
+        u.fail("bad ip: {s}", .{ip}, "", .{});
         return 2;
     } };
     var keys = try loadKeys(io, gpa, cfg_path);
@@ -426,11 +483,11 @@ pub fn unclaim(io: Io, gpa: std.mem.Allocator, ip: []const u8, cfg_path: []const
     var bd: [17]u8 = undefined;
     const info = try boardInfo(io, gpa, &addr, &bd);
     if (info.claimed == false) {
-        log.info("{s} ({s}) is not claimed by anyone", .{ ip, info.bdaddr });
+        u.info("{s} ({s}) is not claimed by anyone", .{ ip, info.bdaddr });
         return revoke(io, gpa, info.bdaddr, cfg_path);
     }
     const psk = settings.lookupPsk(keys.psk, info.bdaddr) orelse {
-        log.err("no key for {s}: this PC did not claim it, so it cannot release it (erase the board over USB instead)", .{info.bdaddr});
+        u.fail("no key for {s}: this PC did not claim it, so it cannot release it (erase the board over USB instead)", .{info.bdaddr}, "", .{});
         return 1;
     };
     var hbuf: [160]u8 = undefined;
@@ -438,14 +495,14 @@ pub fn unclaim(io: Io, gpa: std.mem.Allocator, ip: []const u8, cfg_path: []const
     var r = try httpc.postH(io, gpa, &addr, "/unclaim", "", hdr);
     defer r.deinit(gpa);
     if (r.status == 404) {
-        log.err("{s} runs firmware without unclaim support: run `hcibridge update {s} <esp-hci-bridge-<board>.bin>` first", .{ ip, ip });
+        u.fail("{s} runs firmware without unclaim support: run `hcibridge update {s} <esp-hci-bridge-<board>.bin>` first", .{ ip, ip }, "", .{});
         return 1;
     }
     if (r.status != 200) {
-        log.err("unclaim rejected: HTTP {d} {s}", .{ r.status, std.mem.trim(u8, r.body, " \r\n") });
+        u.fail("unclaim rejected: HTTP {d} {s}", .{ r.status, std.mem.trim(u8, r.body, " \r\n") }, "", .{});
         return 1;
     }
-    log.info("{s} ({s}) forgot its key and is rebooting unclaimed", .{ ip, info.bdaddr });
+    u.info("{s} ({s}) forgot its key and is rebooting unclaimed", .{ ip, info.bdaddr });
     return revoke(io, gpa, info.bdaddr, cfg_path);
 }
 
@@ -453,18 +510,19 @@ pub fn unclaim(io: Io, gpa: std.mem.Allocator, ip: []const u8, cfg_path: []const
 /// written as a drop-in under <config>.d/. First claim wins; re-keying needs
 /// a factory reset of the board.
 pub fn claim(io: Io, gpa: std.mem.Allocator, ip: []const u8, cfg_path: []const u8) !u8 {
+    var u = ui.Ui.init(io);
     const addr: Io.net.IpAddress = .{ .ip4 = Io.net.Ip4Address.parse(ip, httpc.http_port) catch {
-        log.err("bad ip: {s}", .{ip});
+        u.fail("bad ip: {s}", .{ip}, "", .{});
         return 2;
     } };
     var bd: [17]u8 = undefined;
     const info = try boardInfo(io, gpa, &addr, &bd);
     const claimed = info.claimed orelse {
-        log.err("{s} ({s}) runs firmware without key support: update it first.", .{ ip, info.bdaddr });
+        u.fail("{s} ({s}) runs firmware without key support: update it first.", .{ ip, info.bdaddr }, "", .{});
         return 1;
     };
     if (claimed) {
-        log.err("{s} ({s}) is already claimed. To re-key it, factory-reset the board first.", .{ ip, info.bdaddr });
+        u.fail("{s} ({s}) is already claimed. To re-key it, factory-reset the board first.", .{ ip, info.bdaddr }, "", .{});
         return 1;
     }
 
@@ -473,17 +531,17 @@ pub fn claim(io: Io, gpa: std.mem.Allocator, ip: []const u8, cfg_path: []const u
     var r = try httpc.postBinary(io, gpa, &addr, "/claim", &pk_hex);
     defer r.deinit(gpa);
     if (r.status != 200) {
-        log.err("claim rejected: HTTP {d} {s}", .{ r.status, std.mem.trim(u8, r.body, " \r\n") });
+        u.fail("claim rejected: HTTP {d} {s}", .{ r.status, std.mem.trim(u8, r.body, " \r\n") }, "", .{});
         return 1;
     }
     const board_hex = std.mem.trim(u8, r.body, " \r\n");
     var board_pk: [32]u8 = undefined;
     if (board_hex.len != board_pk.len * 2) {
-        log.err("bad board public key in reply: {d} chars, want 64", .{board_hex.len});
+        u.fail("bad board public key in reply: {d} chars, want 64", .{board_hex.len}, "", .{});
         return 1;
     }
     _ = std.fmt.hexToBytes(&board_pk, board_hex) catch {
-        log.err("bad board public key in reply", .{});
+        u.fail("bad board public key in reply", .{}, "", .{});
         return 1;
     };
     const psk = try auth.derivePsk(kp.secret_key, board_pk);
@@ -496,10 +554,10 @@ pub fn claim(io: Io, gpa: std.mem.Allocator, ip: []const u8, cfg_path: []const u
     const dropin = try dropinPath(cfg_path, info.bdaddr, &path_buf);
 
     if (writeFile(io, dropin, line)) {
-        log.info("claimed {s} ({s}); key saved to {s}", .{ ip, info.bdaddr, dropin });
-        log.info("the running daemon picks the key up on the board's next announce", .{});
+        u.info("claimed {s} ({s}); key saved to {s}", .{ ip, info.bdaddr, dropin });
+        u.info("the running daemon picks the key up on the board's next announce", .{});
     } else |err| {
-        log.warn("claimed {s} ({s}) but could not write {s}: {s}", .{ ip, info.bdaddr, dropin, @errorName(err) });
+        u.warn("claimed {s} ({s}) but could not write {s}: {s}", .{ ip, info.bdaddr, dropin, @errorName(err) });
         var obuf: [256]u8 = undefined;
         var out = Io.File.stdout().writer(io, &obuf);
         try out.interface.print("# add this line to {s} (or a .d drop-in):\n{s}", .{ cfg_path, line });

--- a/host/httpc.zig
+++ b/host/httpc.zig
@@ -105,6 +105,13 @@ pub fn postBinary(io: Io, gpa: std.mem.Allocator, addr: *const Io.net.IpAddress,
 
 /// POST with an optional extra header line (without CRLF).
 pub fn postH(io: Io, gpa: std.mem.Allocator, addr: *const Io.net.IpAddress, path: []const u8, body: []const u8, extra: ?[]const u8) !Response {
+    return postProgress(io, gpa, addr, path, body, extra, null, null);
+}
+
+pub const ProgressFn = *const fn (ctx: *anyopaque, sent: usize) void;
+
+/// Like postH, reporting bytes sent so far to `on_progress` as the body goes out.
+pub fn postProgress(io: Io, gpa: std.mem.Allocator, addr: *const Io.net.IpAddress, path: []const u8, body: []const u8, extra: ?[]const u8, on_progress: ?ProgressFn, ctx: ?*anyopaque) !Response {
     var stream = try addr.connect(io, .{ .mode = .stream });
     defer stream.close(io);
     var wbuf: [4096]u8 = undefined;
@@ -112,7 +119,14 @@ pub fn postH(io: Io, gpa: std.mem.Allocator, addr: *const Io.net.IpAddress, path
     try w.interface.print("POST {s} HTTP/1.1\r\nHost: bridge\r\nContent-Type: application/octet-stream\r\nContent-Length: {d}\r\nConnection: close\r\n", .{ path, body.len });
     if (extra) |h| try w.interface.print("{s}\r\n", .{h});
     try w.interface.writeAll("\r\n");
-    try w.interface.writeAll(body);
+    var sent: usize = 0;
+    while (sent < body.len) {
+        const n = @min(16 * 1024, body.len - sent);
+        try w.interface.writeAll(body[sent .. sent + n]);
+        try w.interface.flush();
+        sent += n;
+        if (on_progress) |f| f(ctx.?, sent);
+    }
     try w.interface.flush();
     return readResponse(io, stream, gpa);
 }

--- a/host/release.zig
+++ b/host/release.zig
@@ -3,6 +3,7 @@ const std = @import("std");
 const Io = std.Io;
 
 const log = std.log;
+const ui = @import("ui.zig");
 
 pub const repo = "heppu/esp-hci-bridge";
 const latest_url = "https://github.com/" ++ repo ++ "/releases/latest";
@@ -27,13 +28,13 @@ pub const Latest = struct {
     }
 
     /// Downloads and hash-checks the image for one board preset. Caller frees.
-    pub fn image(self: *Latest, client: *std.http.Client, gpa: std.mem.Allocator, board: []const u8) ![]u8 {
+    pub fn image(self: *Latest, client: *std.http.Client, gpa: std.mem.Allocator, board: []const u8, out: ?*ui.Ui) ![]u8 {
         var nbuf: [128]u8 = undefined;
         const name = try imageName(board, &nbuf);
         const expected = sumFor(self.sums, name) orelse return error.NoSuchBoardImage;
         var url_buf: [256]u8 = undefined;
         const url = try std.fmt.bufPrint(&url_buf, "{s}{s}/{s}", .{ download_base, self.tag, name });
-        const body = try get(client, gpa, url);
+        const body = try getShow(client, gpa, url, out, name);
         errdefer gpa.free(body);
         var digest: [32]u8 = undefined;
         std.crypto.hash.sha2.Sha256.hash(body, &digest, .{});
@@ -75,12 +76,16 @@ fn latestTag(client: *std.http.Client, gpa: std.mem.Allocator) ![]const u8 {
 }
 
 fn get(client: *std.http.Client, gpa: std.mem.Allocator, url: []const u8) ![]u8 {
-    return retry(getOnce, .{ client, gpa, url });
+    return retry(getOnce, .{ client, gpa, url, @as(?*ui.Ui, null), @as([]const u8, "") });
+}
+
+fn getShow(client: *std.http.Client, gpa: std.mem.Allocator, url: []const u8, out: ?*ui.Ui, label: []const u8) ![]u8 {
+    return retry(getOnce, .{ client, gpa, url, out, label });
 }
 
 /// Follows redirects by hand: the client's own redirect path re-encodes the
 /// signed asset URLs GitHub hands out and the CDN answers 400 to the result.
-fn getOnce(client: *std.http.Client, gpa: std.mem.Allocator, url: []const u8) ![]u8 {
+fn getOnce(client: *std.http.Client, gpa: std.mem.Allocator, url: []const u8, out: ?*ui.Ui, label: []const u8) ![]u8 {
     var loc_buf: [4096]u8 = undefined;
     var cur: []const u8 = url;
     var hops: usize = 0;
@@ -111,11 +116,20 @@ fn getOnce(client: *std.http.Client, gpa: std.mem.Allocator, url: []const u8) ![
         }
         var tbuf: [16 * 1024]u8 = undefined;
         const body = res.reader(&tbuf);
-        var out: Io.Writer.Allocating = .init(gpa);
-        defer out.deinit();
-        _ = body.streamRemaining(&out.writer) catch return error.ReadFailed;
-        if (out.written().len > max_body) return error.ResponseTooLarge;
-        return out.toOwnedSlice();
+        const total: usize = @intCast(res.head.content_length orelse 0);
+        var bar: ?ui.Progress = if (out) |u| u.progress("Downloading {s}", .{label}, total) else null;
+        var acc: Io.Writer.Allocating = .init(gpa);
+        defer acc.deinit();
+        while (true) {
+            var chunk: [16 * 1024]u8 = undefined;
+            const n = body.readSliceShort(&chunk) catch return error.ReadFailed;
+            if (n == 0) break;
+            acc.writer.writeAll(chunk[0..n]) catch return error.OutOfMemory;
+            if (acc.written().len > max_body) return error.ResponseTooLarge;
+            if (bar) |*b| b.update(acc.written().len);
+        }
+        if (bar) |*b| b.finish(acc.written().len);
+        return acc.toOwnedSlice();
     }
     return error.TooManyRedirects;
 }

--- a/host/ui.zig
+++ b/host/ui.zig
@@ -1,0 +1,145 @@
+//! Terminal output for the command line tool: steps, progress bars, errors.
+//! Everything goes to stderr so stdout stays usable for data (list, status).
+const std = @import("std");
+const Io = std.Io;
+
+pub const Ui = struct {
+    io: Io,
+    file: Io.File,
+    tty: bool,
+    /// A step is open from `step` until `done` or `fail` closes its line.
+    open: bool = false,
+
+    pub fn init(io: Io) Ui {
+        const f = Io.File.stderr();
+        return .{ .io = io, .file = f, .tty = f.isTty(io) catch false };
+    }
+
+    fn write(self: *Ui, bytes: []const u8) void {
+        var buf: [256]u8 = undefined;
+        var w = self.file.writer(self.io, &buf);
+        w.interface.writeAll(bytes) catch return;
+        w.interface.flush() catch {};
+    }
+
+    fn print(self: *Ui, comptime fmt: []const u8, args: anytype) void {
+        var buf: [1024]u8 = undefined;
+        const s = std.fmt.bufPrint(&buf, fmt, args) catch return;
+        self.write(s);
+    }
+
+    /// Starts a line that `done` completes: "Checking the latest release... v1.2".
+    pub fn step(self: *Ui, comptime fmt: []const u8, args: anytype) void {
+        if (self.open) self.write("\n");
+        self.print(fmt ++ "...", args);
+        self.open = true;
+    }
+
+    pub fn done(self: *Ui, comptime fmt: []const u8, args: anytype) void {
+        self.print(" " ++ fmt ++ "\n", args);
+        self.open = false;
+    }
+
+    /// A complete line on its own.
+    pub fn info(self: *Ui, comptime fmt: []const u8, args: anytype) void {
+        if (self.open) self.write("\n");
+        self.open = false;
+        self.print(fmt ++ "\n", args);
+    }
+
+    pub fn warn(self: *Ui, comptime fmt: []const u8, args: anytype) void {
+        self.info("warning: " ++ fmt, args);
+    }
+
+    /// The problem on one line, what to do about it on the next.
+    pub fn fail(self: *Ui, comptime what: []const u8, what_args: anytype, comptime hint: []const u8, hint_args: anytype) void {
+        if (self.open) self.write("\n");
+        self.open = false;
+        self.print("error: " ++ what ++ "\n", what_args);
+        if (hint.len > 0) self.print("  " ++ hint ++ "\n", hint_args);
+    }
+
+    /// A progress bar that redraws in place on a terminal and stays quiet
+    /// otherwise, apart from the final line.
+    pub fn progress(self: *Ui, comptime label: []const u8, args: anytype, total: usize) Progress {
+        var p = Progress{ .ui = self, .total = total };
+        p.label_len = if (std.fmt.bufPrint(&p.label, label, args)) |s| s.len else |_| 0;
+        if (self.open) self.write("\n");
+        self.open = false;
+        p.draw(0, true);
+        return p;
+    }
+};
+
+pub const Progress = struct {
+    ui: *Ui,
+    total: usize,
+    label: [64]u8 = undefined,
+    label_len: usize = 0,
+    last_pct: usize = 101,
+    finished: bool = false,
+
+    pub fn update(self: *Progress, done: usize) void {
+        self.draw(done, false);
+    }
+
+    pub fn finish(self: *Progress, done: usize) void {
+        if (self.finished) return;
+        self.finished = true;
+        const pct: usize = if (self.total == 0) 100 else @min(100, done * 100 / self.total);
+        if (pct != self.last_pct) self.draw(done, true);
+        if (self.ui.tty) self.ui.write("\n");
+    }
+
+    fn draw(self: *Progress, done: usize, force: bool) void {
+        const pct: usize = if (self.total == 0) 100 else @min(100, done * 100 / self.total);
+        if (!force and pct == self.last_pct) return;
+        if (!self.ui.tty and !force) return;
+        self.last_pct = pct;
+        var bar: [20]u8 = undefined;
+        const filled = pct * bar.len / 100;
+        for (&bar, 0..) |*c, i| c.* = if (i < filled) '#' else '.';
+        var kb: [2][]const u8 = .{ "", "" };
+        var b1: [16]u8 = undefined;
+        var b2: [16]u8 = undefined;
+        kb[0] = human(done, &b1);
+        kb[1] = human(self.total, &b2);
+        if (self.ui.tty) self.ui.write("\r");
+        self.ui.print("{s}  [{s}] {d: >3}%  {s} of {s}", .{ self.label[0..self.label_len], &bar, pct, kb[0], kb[1] });
+        if (!self.ui.tty) self.ui.write("\n");
+    }
+};
+
+fn human(n: usize, buf: *[16]u8) []const u8 {
+    if (n >= 1024 * 1024) return std.fmt.bufPrint(buf, "{d}.{d} MB", .{ n / (1024 * 1024), (n % (1024 * 1024)) * 10 / (1024 * 1024) }) catch "?";
+    if (n >= 1024) return std.fmt.bufPrint(buf, "{d} KB", .{n / 1024}) catch "?";
+    return std.fmt.bufPrint(buf, "{d} B", .{n}) catch "?";
+}
+
+/// "a.b.c.d" without the port, for messages about a board.
+pub fn ipOf(addr: *const Io.net.IpAddress, buf: *[48]u8) []const u8 {
+    return switch (addr.*) {
+        .ip4 => |v| std.fmt.bufPrint(buf, "{d}.{d}.{d}.{d}", .{ v.bytes[0], v.bytes[1], v.bytes[2], v.bytes[3] }) catch "?",
+        else => std.fmt.bufPrint(buf, "{f}", .{addr.*}) catch "?",
+    };
+}
+
+/// Plain words for the errors a user can actually do something about.
+pub fn explain(err: anyerror) []const u8 {
+    return switch (err) {
+        error.NameServerFailure, error.TemporaryNameServerFailure, error.UnknownHostName, error.HostLacksNetworkAddresses => "name lookup failed, is DNS working?",
+        error.ConnectionRefused => "connection refused",
+        error.ConnectionTimedOut, error.Timeout => "connection timed out",
+        error.NetworkUnreachable => "network unreachable",
+        error.ConnectionResetByPeer, error.EndOfStream, error.HttpConnectionClosing => "connection dropped",
+        error.TlsInitializationFailed, error.CertificateBundleLoadFailure => "TLS setup failed, are system CA certificates installed?",
+        error.ChecksumMismatch => "the downloaded image does not match the release checksums",
+        error.NoSuchBoardImage => "the release has no image for that board",
+        error.HttpStatus => "unexpected HTTP status (see above)",
+        error.AuthFailed => "the board rejected this key",
+        error.HandshakeTimeout => "the board did not answer the handshake",
+        error.FileNotFound => "file not found",
+        error.AccessDenied => "permission denied",
+        else => @errorName(err),
+    };
+}


### PR DESCRIPTION
- New `host/ui.zig`: steps that complete on the same line, progress bars that redraw in place on a terminal and print start and end lines otherwise, and errors as "what went wrong" plus an indented "what to do" line. Everything on stderr, stdout stays for data.
- `update`: shows the release found, a download bar, the checksum result, the board's identity and current version, an upload bar, then waits for the board to come back and reports the version it runs, warning if it rolled back. No more bare error names, no more stray indentation.
- `claim`, `revoke`, `unclaim`, `reboot`, `status` use the same layer.
- Board HTTP rejections print the board's own message and a hint by status (401/403 key mismatch, 413 image too large).

Checked under a pseudo terminal and piped.