### PR TITLE
Build the Arch, Alpine, and Void recipes in containers on every release, make the Void template fetch its own Zig

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,8 +188,23 @@ jobs:
           name: pkg-repos
           path: repo/
 
+  # The source recipes on the release page, built the way each distro builds them.
+  recipes:
+    needs: cli
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distro: [arch, alpine, void]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: cli
+          path: cli
+      - run: packaging/verify-recipes.sh cli "${GITHUB_REF_NAME}" ${{ matrix.distro }}
+
   release:
-    needs: [site, cli]
+    needs: [site, cli, recipes]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -72,7 +72,10 @@ echo https://heppu.github.io/esp-hci-bridge/alpine | sudo tee -a /etc/apk/reposi
 sudo apk add hcibridge
 ```
 
-Plain package files are on the release page as well.
+Plain package files are on the release page as well, next to a `PKGBUILD` for
+Arch, an `APKBUILD` (needs Alpine edge for its Zig), and a Void template that
+fetches its own Zig. Every release builds all three the way their distro does
+before it is published.
 
 Arch has a `PKGBUILD` and Void a template on the release page. The package
 installs a background service that starts on boot and finds boards on its own.

--- a/packaging/verify-recipes.sh
+++ b/packaging/verify-recipes.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# Builds the source recipes the way their distros do, in containers, and
+# installs the result: PKGBUILD with makepkg on Arch, APKBUILD with abuild on
+# Alpine edge, the Void template with xbps-src. Needs docker.
+# Usage: packaging/verify-recipes.sh <dir with rendered PKGBUILD, APKBUILD, void-template> [version] [arch|alpine|void|all]
+set -eu
+DIR=$(cd "$1" && pwd)
+VER=${2:-}
+WHICH=${3:-all}
+want() { [ "$WHICH" = all ] || [ "$WHICH" = "$1" ]; }
+
+check() {
+    got=$(cat)
+    echo "$got"
+    echo "$got" | grep -q '^installed: ' || { echo "install did not happen" >&2; exit 1; }
+    [ -z "$VER" ] || echo "$got" | grep -q "$VER" || { echo "expected version $VER" >&2; exit 1; }
+}
+
+want arch && { echo "== arch (makepkg)"
+docker run --rm -v "$DIR:/in:ro" archlinux:latest bash -euc '
+  pacman -Syu --noconfirm --needed base-devel zig bluez >/dev/null 2>&1
+  useradd -m b && mkdir /b && cp /in/PKGBUILD /b/ && chown -R b /b
+  su b -c "cd /b && makepkg --noconfirm >/dev/null 2>&1"
+  pacman -U --noconfirm /b/hcibridge-[0-9]*-x86_64.pkg.tar.zst >/dev/null 2>&1
+  echo "installed: $(hcibridge --version)"' | check; }
+
+want alpine && { echo "== alpine edge (abuild)"
+docker run --rm -v "$DIR:/in:ro" alpine:edge sh -euc '
+  apk add -q --no-cache alpine-sdk zig >/dev/null 2>&1
+  adduser -D b && addgroup b abuild && mkdir /b && cp /in/APKBUILD /b/ && chown -R b /b
+  su b -c "abuild-keygen -an >/dev/null 2>&1"
+  cp /home/b/.config/abuild/*.rsa.pub /etc/apk/keys/ 2>/dev/null || cp /home/b/.abuild/*.rsa.pub /etc/apk/keys/
+  su b -c "cd /b && abuild -r >/dev/null 2>&1 || abuild -r 2>&1 | tail -5"
+  apk add -q $(find /home/b -name "hcibridge-[0-9]*.apk" -o -name "hcibridge-openrc-*.apk")
+  echo "installed: $(hcibridge --version)"' | check; }
+
+want void && { echo "== void (xbps-src)"
+# Void's own CI recipe for running xbps-src as root in a container.
+docker run --rm --privileged -v "$DIR:/in:ro" ghcr.io/void-linux/void-buildroot-glibc:latest sh -euc '
+  xbps-install -Sy git >/dev/null 2>&1
+  cd /tmp && git clone -q --depth 1 https://github.com/void-linux/void-packages.git && cd void-packages
+  echo XBPS_CHROOT_CMD=ethereal >> etc/conf
+  echo XBPS_ALLOW_CHROOT_BREAKOUT=yes >> etc/conf
+  ln -s / masterdir
+  mkdir -p srcpkgs/hcibridge && cp /in/void-template srcpkgs/hcibridge/template
+  ./xbps-src pkg hcibridge >/dev/null 2>&1 || ./xbps-src pkg hcibridge 2>&1 | tail -15
+  xbps-rindex -a hostdir/binpkgs/*.xbps >/dev/null 2>&1
+  xbps-install -Sy --repository=hostdir/binpkgs hcibridge >/dev/null 2>&1
+  echo "installed: $(hcibridge --version)"' | check; }
+
+echo "recipes ok ($WHICH)"

--- a/packaging/void-template.tmpl
+++ b/packaging/void-template.tmpl
@@ -1,21 +1,34 @@
 # Template file for 'hcibridge'
 # Drop this in void-packages as srcpkgs/hcibridge/template and run xbps-src.
+# Void ships an older Zig, so the build fetches Zig 0.16 for the build host
+# and cross-compiles from there, which Zig does on its own.
 pkgname=hcibridge
 version=@PKGVER@
 revision=1
-hostmakedepends="zig"
+archs="x86_64 aarch64"
+create_wrksrc=yes
+build_wrksrc="esp-hci-bridge-${version}"
 depends="bluez"
 short_desc="Attach remote ESP32 Bluetooth bridges to the local Bluetooth stack"
 maintainer="Henri Koski <henri.koski@bitbrewers.fi>"
 license="MIT"
 homepage="https://github.com/heppu/esp-hci-bridge"
-distfiles="https://github.com/heppu/esp-hci-bridge/archive/refs/tags/v${version}.tar.gz"
-checksum=@SHA256@
+_zigver=0.16.0
+case "$XBPS_MACHINE" in
+	x86_64) _zigsum=70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00 ;;
+	aarch64) _zigsum=ea4b09bfb22ec6f6c6ceac57ab63efb6b46e17ab08d21f69f3a48b38e1534f17 ;;
+esac
+_zig="zig-${XBPS_MACHINE}-linux-${_zigver}"
+distfiles="https://github.com/heppu/esp-hci-bridge/archive/refs/tags/v${version}.tar.gz
+ https://ziglang.org/download/${_zigver}/${_zig}.tar.xz"
+checksum="@SHA256@
+ ${_zigsum}"
 conf_files="/etc/hcibridge/config /etc/hcibridge/config.d/50-example.conf /etc/hcibridge.conf"
 
 do_build() {
-	zig build -Doptimize=ReleaseSafe "-Dversion=v${version}"
-	zig build gen "-Dversion=v${version}"
+	export ZIG_GLOBAL_CACHE_DIR="${wrksrc}/zig-cache"
+	"${wrksrc}/${_zig}/zig" build -Doptimize=ReleaseSafe "-Dtarget=${XBPS_TARGET_MACHINE}-linux-musl" "-Dversion=v${version}"
+	"${wrksrc}/${_zig}/zig" build gen "-Dversion=v${version}"
 }
 
 do_install() {


### PR DESCRIPTION
Ran the three source recipes from the v0.10.15 release page the way their distros do, in containers.

- Arch `PKGBUILD`: built and installed as is, Arch ships Zig 0.16.
- Alpine `APKBUILD`: built and installed on edge, which has Zig 0.16. Stable Alpine has 0.14, so the recipe is edge-only, noted in the README. Stable users have the repository.
- Void template: could not build, Void ships Zig 0.13. Rewritten to fetch the Zig 0.16 tarball for the build host as a checksummed second distfile and cross-compile with `-Dtarget`, x86_64 and aarch64. Builds and installs now.

`packaging/verify-recipes.sh` does all of that (makepkg, abuild, xbps-src with Void's own container settings) and the release workflow runs it as a three-way matrix that gates the release.