### PR TITLE
Publish the PKGBUILD to the AUR on every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,6 +254,40 @@ jobs:
           fail_on_unmatched_files: true
           generate_release_notes: true
 
+  # Keeps aur.archlinux.org/packages/hcibridge on the released version.
+  aur:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: cli
+          path: cli
+      - name: Generate .SRCINFO
+        run: |
+          mkdir aur && cp cli/PKGBUILD aur/
+          docker run --rm -v "$PWD/aur:/w" archlinux:latest bash -euc '
+            pacman -Sy --noconfirm --needed base-devel >/dev/null 2>&1
+            useradd -m b && chown b /w
+            su b -c "cd /w && makepkg --printsrcinfo > .SRCINFO"
+            chown '"$(id -u)"' /w/.SRCINFO'
+          cat aur/.SRCINFO
+      - name: Push to the AUR
+        env:
+          KEY: ${{ secrets.AUR_SSH_KEY }}
+        run: |
+          test -n "$KEY" || { echo "AUR_SSH_KEY secret missing, skipping"; exit 0; }
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$KEY" > ~/.ssh/aur && chmod 600 ~/.ssh/aur
+          ssh-keyscan -t ed25519 aur.archlinux.org >> ~/.ssh/known_hosts 2>/dev/null
+          export GIT_SSH_COMMAND="ssh -i ~/.ssh/aur -o IdentitiesOnly=yes"
+          git clone -q ssh://aur@aur.archlinux.org/hcibridge.git repo
+          cp aur/PKGBUILD aur/.SRCINFO repo/
+          cd repo
+          git add PKGBUILD .SRCINFO
+          git -c user.name="esp-hci-bridge release" -c user.email="henri.koski@bitbrewers.fi" commit -qm "hcibridge ${GITHUB_REF_NAME#v}" || { echo "AUR already current"; exit 0; }
+          git push -q origin HEAD:master
+
   pages:
     needs: release
     runs-on: ubuntu-latest

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -118,6 +118,13 @@ an Alpine container and signs it the way `abuild-sign` does. Losing the
 private key means users have to fetch and trust a new public key, so keep a
 copy outside CI, like the firmware key.
 
+## AUR
+
+`hcibridge` on the AUR builds from the release tarball with the `PKGBUILD` the
+release renders. The release workflow regenerates `.SRCINFO` in an Arch
+container and pushes both to `ssh://aur@aur.archlinux.org/hcibridge.git` with
+the `AUR_SSH_KEY` secret (the matching public key is on the AUR account).
+
 ## Releasing
 
 Push a `v*` tag on a commit that is on `main`. The workflow refuses tags that


### PR DESCRIPTION
After the GitHub release exists, an `aur` job regenerates `.SRCINFO` from the rendered PKGBUILD in an Arch container and pushes both to the AUR package over SSH with the `AUR_SSH_KEY` secret. Skips cleanly when the secret is absent, no-ops when the AUR is already current.