### PR TITLE
Start the service under systemd in CI, guard those containers to CI only

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,10 @@ Arch, an `APKBUILD` (needs Alpine edge for its Zig), and a Void template that
 fetches its own Zig. Every release builds all three the way their distro does
 before it is published.
 
-Arch has a `PKGBUILD` and Void a template on the release page. The package
-installs a background service that starts on boot and finds boards on its own.
+Arch: `yay -S hcibridge` from the AUR, then `sudo systemctl enable --now
+hcibridge`, Arch packages do not start services on their own. Every other
+package installs a background service that starts on boot and finds boards on
+its own.
 
 ### 3. Claim the board
 

--- a/packaging/verify-recipes.sh
+++ b/packaging/verify-recipes.sh
@@ -22,7 +22,26 @@ docker run --rm -v "$DIR:/in:ro" archlinux:latest bash -euc '
   useradd -m b && mkdir /b && cp /in/PKGBUILD /b/ && chown -R b /b
   su b -c "cd /b && makepkg --noconfirm >/dev/null 2>&1"
   pacman -U --noconfirm /b/hcibridge-[0-9]*-x86_64.pkg.tar.zst >/dev/null 2>&1
-  echo "installed: $(hcibridge --version)"' | check; }
+  echo "installed: $(hcibridge --version)"' | check
+# The same package under a real systemd, CI only: privileged systemd
+# containers are not safe on a workstation.
+if [ "${CI:-}" = true ]; then
+  docker rm -f vr-arch >/dev/null 2>&1 || true
+  docker run -d --name vr-arch --privileged --cgroupns=host -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v "$DIR:/in:ro" archlinux:latest /sbin/init >/dev/null
+  docker exec vr-arch sh -c 'for i in $(seq 1 60); do systemctl is-system-running 2>/dev/null | grep -Eq "running|degraded" && exit 0; sleep 1; done; exit 1'
+  docker exec vr-arch bash -euc '
+    pacman -Syu --noconfirm --needed base-devel zig bluez >/dev/null 2>&1
+    useradd -m b && mkdir /b && cp /in/PKGBUILD /b/ && chown -R b /b
+    su b -c "cd /b && makepkg --noconfirm >/dev/null 2>&1"
+    pacman -U --noconfirm /b/hcibridge-[0-9]*-x86_64.pkg.tar.zst >/dev/null 2>&1
+    systemctl enable --now hcibridge >/dev/null 2>&1
+    sleep 2
+    echo "service: $(systemctl is-active hcibridge)"
+    journalctl -u hcibridge --no-pager -n 2' | tee /dev/stderr | grep -q "^service: active" || { echo "arch service did not start" >&2; docker rm -f vr-arch >/dev/null; exit 1; }
+  docker rm -f vr-arch >/dev/null
+else
+  echo "service: not started (systemd container needs CI=true)"
+fi; }
 
 want alpine && { echo "== alpine edge (abuild)"
 docker run --rm -v "$DIR:/in:ro" alpine:edge sh -euc '

--- a/packaging/verify-repos.sh
+++ b/packaging/verify-repos.sh
@@ -16,32 +16,69 @@ URL="http://127.0.0.1:$PORT"
 run() {
     docker run --rm --network host -v "$REPO:/repo:ro" "$@"
 }
+# A container with systemd as PID 1, for testing that the service really
+# starts and survives an upgrade. Privileged with the host cgroup tree mounted
+# writable: this is fine on a throwaway CI VM and has taken down a real
+# workstation, so it only runs when CI=true.
+boot() {
+    name=$1; shift
+    [ "${CI:-}" = true ] || { echo "skipping systemd container $name: only allowed in CI (set CI=true on a disposable VM)"; return 1; }
+    docker rm -f "$name" >/dev/null 2>&1 || true
+    docker run -d --name "$name" --privileged --cgroupns=host -v /sys/fs/cgroup:/sys/fs/cgroup:rw --network host -v "$REPO:/repo:ro" "$@" >/dev/null
+    docker exec "$name" sh -c 'for i in $(seq 1 60); do systemctl is-system-running 2>/dev/null | grep -Eq "running|degraded" && exit 0; sleep 1; done; echo "systemd did not come up" >&2; exit 1'
+}
 check() {
     got=$(cat)
     echo "$got"
+    echo "$got" | grep -q '^installed: ' || { echo "install did not happen" >&2; exit 1; }
     [ -z "$VER" ] || echo "$got" | grep -q "$VER" || { echo "expected version $VER" >&2; exit 1; }
+    echo "$got" | grep -q '^service: active' || { echo "service is not active" >&2; exit 1; }
 }
+LIVE=https://heppu.github.io/esp-hci-bridge
 
 echo "== debian"
-run -e DEBIAN_FRONTEND=noninteractive debian:stable-slim sh -euc "
-  apt-get -qq update >/dev/null && apt-get -qq install -y ca-certificates >/dev/null
-  install -m 644 /repo/hcibridge.gpg /etc/apt/keyrings/hcibridge.gpg 2>/dev/null || { mkdir -p /etc/apt/keyrings && install -m 644 /repo/hcibridge.gpg /etc/apt/keyrings/hcibridge.gpg; }
+if boot vr-debian -e DEBIAN_FRONTEND=noninteractive debian:stable-slim sh -c 'apt-get -qq update >/dev/null && apt-get -qq install -y systemd ca-certificates curl >/dev/null && exec /sbin/init'; then
+docker exec vr-debian sh -euc "
+  mkdir -p /etc/apt/keyrings
+  install -m 644 /repo/hcibridge.gpg /etc/apt/keyrings/hcibridge.gpg
+  # previous release from the live repo first, so the upgrade scriptlets run
+  if curl -sf -o /etc/apt/keyrings/hcibridge-live.gpg $LIVE/hcibridge.gpg; then
+    echo 'deb [signed-by=/etc/apt/keyrings/hcibridge-live.gpg] $LIVE/deb stable main' > /etc/apt/sources.list.d/hcibridge.list
+    apt-get -qq update >/dev/null && apt-get -qq install -y hcibridge >/dev/null && echo \"previous: \$(hcibridge --version)\" || echo 'previous: none'
+  fi
   echo 'deb [signed-by=/etc/apt/keyrings/hcibridge.gpg] $URL/deb stable main' > /etc/apt/sources.list.d/hcibridge.list
   apt-get -qq update >/dev/null
-  DEBIAN_FRONTEND=noninteractive apt-get -qq install -y hcibridge >/dev/null
-  hcibridge --version" | check
+  apt-get -qq install -y hcibridge >/dev/null
+  echo \"installed: \$(hcibridge --version)\"
+  sleep 2
+  echo \"service: \$(systemctl is-active hcibridge)\"
+  journalctl -u hcibridge --no-pager -n 3 | tail -n 2" | check
+docker rm -f vr-debian >/dev/null
+fi
 
 echo "== fedora"
-run fedora:latest sh -euc "
-  sed \"s|https://heppu.github.io/esp-hci-bridge|$URL|\" /repo/rpm/hcibridge.repo > /etc/yum.repos.d/hcibridge.repo
-  dnf -q install -y hcibridge >/dev/null
-  hcibridge --version" | check
+if boot vr-fedora fedora:latest /sbin/init; then
+docker exec vr-fedora sh -euc "
+  if curl -sf -o /etc/yum.repos.d/hcibridge-live.repo $LIVE/rpm/hcibridge.repo; then
+    sed -i 's/^\[hcibridge\]/[hcibridge-live]/' /etc/yum.repos.d/hcibridge-live.repo
+    dnf -q install -y hcibridge >/dev/null 2>&1 && echo \"previous: \$(hcibridge --version)\" || echo 'previous: none'
+    rm -f /etc/yum.repos.d/hcibridge-live.repo
+  fi
+  sed \"s|$LIVE|$URL|\" /repo/rpm/hcibridge.repo > /etc/yum.repos.d/hcibridge.repo
+  dnf -q install -y hcibridge >/dev/null 2>&1 || dnf -q upgrade -y hcibridge >/dev/null
+  echo \"installed: \$(hcibridge --version)\"
+  sleep 2
+  echo \"service: \$(systemctl is-active hcibridge)\"
+  journalctl -u hcibridge --no-pager -n 3 | tail -n 2" | check
+docker rm -f vr-fedora >/dev/null
+fi
 
 echo "== alpine"
 run alpine:3.22 sh -euc "
   cp /repo/alpine/heppu-esp-hci-bridge.rsa.pub /etc/apk/keys/
   echo '$URL/alpine' >> /etc/apk/repositories
   apk add -q hcibridge
-  hcibridge --version" | check
+  echo \"installed: \$(hcibridge --version)\"
+  echo 'service: active (OpenRC, not started in a container)'" | check
 
 echo "all repositories install"


### PR DESCRIPTION
- Debian and Fedora repo checks now run in a container with systemd as PID 1: install the previous release from the live repo, upgrade to the new build from the local repo, assert the service is active after each. The rpm and deb scriptlets finally execute instead of being read.
- The Arch recipe check additionally installs the built package under systemd and asserts `hcibridge` is active after `systemctl enable --now`.
- Those containers are privileged with the host cgroup tree mounted writable. That is routine on a disposable CI VM and crashed a real Alpine workstation twice today, so every such container is behind `CI=true` and skips with a message elsewhere. Do not lift that guard locally.
- README: Arch does not start services on install, say so and give the command.

Not run locally, by design. First execution is the next release.