### PR TITLE
Site and README: distributions in alphabetical order

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ Download the package for your distro from the
 Every distro gets a signed package repository, so the normal upgrade command
 keeps the tool current afterwards.
 
+Alpine:
+
+```sh
+sudo wget -O /etc/apk/keys/heppu-esp-hci-bridge.rsa.pub https://heppu.github.io/esp-hci-bridge/alpine/heppu-esp-hci-bridge.rsa.pub
+echo https://heppu.github.io/esp-hci-bridge/alpine | sudo tee -a /etc/apk/repositories
+sudo apk add hcibridge
+```
+
 Debian, Ubuntu:
 
 ```sh
@@ -97,14 +105,6 @@ Fedora, RHEL:
 ```sh
 sudo curl -fsSLo /etc/yum.repos.d/hcibridge.repo https://heppu.github.io/esp-hci-bridge/rpm/hcibridge.repo
 sudo dnf install hcibridge
-```
-
-Alpine:
-
-```sh
-sudo wget -O /etc/apk/keys/heppu-esp-hci-bridge.rsa.pub https://heppu.github.io/esp-hci-bridge/alpine/heppu-esp-hci-bridge.rsa.pub
-echo https://heppu.github.io/esp-hci-bridge/alpine | sudo tee -a /etc/apk/repositories
-sudo apk add hcibridge
 ```
 
 Plain package files are on the release page as well, next to a `PKGBUILD` for

--- a/web/index.html
+++ b/web/index.html
@@ -95,25 +95,14 @@
   <p class="lede">One package. It installs the <code>hcibridge</code> command and a background service that starts on boot and finds boards on its own.</p>
 
   <ul class="tabs" role="tablist" aria-label="Distribution" data-group="distro">
-    <li><button role="tab" aria-selected="true" data-tab="deb">Debian, Ubuntu</button></li>
-    <li><button role="tab" aria-selected="false" data-tab="rpm">Fedora, RHEL</button></li>
-    <li><button role="tab" aria-selected="false" data-tab="apk">Alpine</button></li>
+    <li><button role="tab" aria-selected="true" data-tab="apk">Alpine</button></li>
     <li><button role="tab" aria-selected="false" data-tab="arch">Arch</button></li>
+    <li><button role="tab" aria-selected="false" data-tab="deb">Debian, Ubuntu</button></li>
+    <li><button role="tab" aria-selected="false" data-tab="rpm">Fedora, RHEL</button></li>
     <li><button role="tab" aria-selected="false" data-tab="void">Void</button></li>
     <li><button role="tab" aria-selected="false" data-tab="other">Other</button></li>
   </ul>
-  <div class="panel" data-panel="deb">
-<pre><code>sudo curl -fsSLo /etc/apt/keyrings/hcibridge.gpg https://heppu.github.io/esp-hci-bridge/hcibridge.gpg
-echo "deb [signed-by=/etc/apt/keyrings/hcibridge.gpg] https://heppu.github.io/esp-hci-bridge/deb stable main" | sudo tee /etc/apt/sources.list.d/hcibridge.list
-sudo apt update &amp;&amp; sudo apt install hcibridge</code></pre>
-    <p class="meta">A signed repository for <code>amd64</code>, <code>arm64</code>, and <code>armhf</code>. <code>apt upgrade</code> picks up new releases.</p>
-  </div>
-  <div class="panel" data-panel="rpm" hidden>
-<pre><code>sudo curl -fsSLo /etc/yum.repos.d/hcibridge.repo https://heppu.github.io/esp-hci-bridge/rpm/hcibridge.repo
-sudo dnf install hcibridge</code></pre>
-    <p class="meta">A signed repository for <code>x86_64</code>, <code>aarch64</code>, and <code>armhfp</code>. <code>dnf upgrade</code> picks up new releases.</p>
-  </div>
-  <div class="panel" data-panel="apk" hidden>
+  <div class="panel" data-panel="apk">
 <pre><code>sudo wget -O /etc/apk/keys/heppu-esp-hci-bridge.rsa.pub https://heppu.github.io/esp-hci-bridge/alpine/heppu-esp-hci-bridge.rsa.pub
 echo https://heppu.github.io/esp-hci-bridge/alpine | sudo tee -a /etc/apk/repositories
 sudo apk add hcibridge</code></pre>
@@ -123,6 +112,17 @@ sudo apk add hcibridge</code></pre>
 <pre><code>yay -S hcibridge
 sudo systemctl enable --now hcibridge</code></pre>
     <p class="meta">From the <a href="https://aur.archlinux.org/packages/hcibridge">AUR</a>, built from source with the Zig in the Arch repos. Arch does not start services on install, hence the second line. Any AUR helper works, or <code>makepkg -si</code> on the PKGBUILD from the release page.</p>
+  </div>
+  <div class="panel" data-panel="deb" hidden>
+<pre><code>sudo curl -fsSLo /etc/apt/keyrings/hcibridge.gpg https://heppu.github.io/esp-hci-bridge/hcibridge.gpg
+echo "deb [signed-by=/etc/apt/keyrings/hcibridge.gpg] https://heppu.github.io/esp-hci-bridge/deb stable main" | sudo tee /etc/apt/sources.list.d/hcibridge.list
+sudo apt update &amp;&amp; sudo apt install hcibridge</code></pre>
+    <p class="meta">A signed repository for <code>amd64</code>, <code>arm64</code>, and <code>armhf</code>. <code>apt upgrade</code> picks up new releases.</p>
+  </div>
+  <div class="panel" data-panel="rpm" hidden>
+<pre><code>sudo curl -fsSLo /etc/yum.repos.d/hcibridge.repo https://heppu.github.io/esp-hci-bridge/rpm/hcibridge.repo
+sudo dnf install hcibridge</code></pre>
+    <p class="meta">A signed repository for <code>x86_64</code>, <code>aarch64</code>, and <code>armhfp</code>. <code>dnf upgrade</code> picks up new releases.</p>
   </div>
   <div class="panel" data-panel="void" hidden>
 <pre><code>curl -LO https://github.com/heppu/esp-hci-bridge/releases/latest/download/void-template


### PR DESCRIPTION
Alpine, Arch, Debian, Fedora, Void, then Other. README install blocks in the same order.