### PR TITLE
Add hcibridge-bin to the AUR publish and recipe check, fix the systemd containers for Debian and Fedora

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,13 @@ jobs:
           SHA512=$(sha512sum src.tar.gz | cut -d' ' -f1)
           sed -e "s/@PKGVER@/$VER/" -e "s/@SHA256@/$SHA/" packaging/PKGBUILD.tmpl > out/PKGBUILD
           sed -e "s/@PKGVER@/$VER/" -e "s/@SHA512@/$SHA512/" packaging/APKBUILD.tmpl > out/APKBUILD
+          # the -bin PKGBUILD pins every release asset it downloads
+          h() { sha256sum "out/$1" | cut -d' ' -f1; }
+          sed -e "s/@PKGVER@/$VER/" -e "s/@SHA256@/$SHA/" \
+              -e "s/@SHA_MAN@/$(h hcibridge.1)/" -e "s/@SHA_BASH@/$(h hcibridge.bash)/" \
+              -e "s/@SHA_ZSH@/$(h _hcibridge)/" -e "s/@SHA_FISH@/$(h hcibridge.fish)/" \
+              -e "s/@SHA_X86_64@/$(h hcibridge-x86_64-linux)/" -e "s/@SHA_AARCH64@/$(h hcibridge-aarch64-linux)/" \
+              -e "s/@SHA_ARMV7@/$(h hcibridge-armv7-linux)/" packaging/PKGBUILD-bin.tmpl > out/PKGBUILD-bin
           sed -e "s/@PKGVER@/$VER/" -e "s/@SHA256@/$SHA/" packaging/void-template.tmpl > out/void-template
           ls -1 out/
       - name: Build the Alpine repository
@@ -263,15 +270,16 @@ jobs:
         with:
           name: cli
           path: cli
-      - name: Generate .SRCINFO
+      - name: Generate .SRCINFO for both packages
         run: |
-          mkdir aur && cp cli/PKGBUILD aur/
+          mkdir -p aur/hcibridge aur/hcibridge-bin
+          cp cli/PKGBUILD aur/hcibridge/PKGBUILD
+          cp cli/PKGBUILD-bin aur/hcibridge-bin/PKGBUILD
           docker run --rm -v "$PWD/aur:/w" archlinux:latest bash -euc '
-            pacman -Sy --noconfirm --needed base-devel >/dev/null 2>&1
-            useradd -m b && chown b /w
-            su b -c "cd /w && makepkg --printsrcinfo > .SRCINFO"
-            chown '"$(id -u)"' /w/.SRCINFO'
-          cat aur/.SRCINFO
+            useradd -m b && chown -R b /w
+            for d in /w/*/; do su b -c "cd $d && makepkg --printsrcinfo > .SRCINFO"; done
+            chown -R '"$(id -u)"' /w'
+          cat aur/*/.SRCINFO
       - name: Push to the AUR
         env:
           KEY: ${{ secrets.AUR_SSH_KEY }}
@@ -281,12 +289,14 @@ jobs:
           printf '%s\n' "$KEY" > ~/.ssh/aur && chmod 600 ~/.ssh/aur
           ssh-keyscan -t ed25519 aur.archlinux.org >> ~/.ssh/known_hosts 2>/dev/null
           export GIT_SSH_COMMAND="ssh -i ~/.ssh/aur -o IdentitiesOnly=yes"
-          git clone -q ssh://aur@aur.archlinux.org/hcibridge.git repo
-          cp aur/PKGBUILD aur/.SRCINFO repo/
-          cd repo
-          git add PKGBUILD .SRCINFO
-          git -c user.name="esp-hci-bridge release" -c user.email="henri.koski@bitbrewers.fi" commit -qm "hcibridge ${GITHUB_REF_NAME#v}" || { echo "AUR already current"; exit 0; }
-          git push -q origin HEAD:master
+          for pkg in hcibridge hcibridge-bin; do
+            git clone -q "ssh://aur@aur.archlinux.org/$pkg.git" "repo-$pkg"
+            cp "aur/$pkg/PKGBUILD" "aur/$pkg/.SRCINFO" "repo-$pkg/"
+            ( cd "repo-$pkg"
+              git add PKGBUILD .SRCINFO
+              git -c user.name="esp-hci-bridge release" -c user.email="henri.koski@bitbrewers.fi" commit -qm "$pkg ${GITHUB_REF_NAME#v}" || { echo "$pkg already current"; exit 0; }
+              git push -q origin HEAD:master )
+          done
 
   pages:
     needs: release

--- a/packaging/PKGBUILD-bin.tmpl
+++ b/packaging/PKGBUILD-bin.tmpl
@@ -1,0 +1,40 @@
+# Maintainer: Henri Koski <henri.koski@bitbrewers.fi>
+pkgname=hcibridge-bin
+pkgver=@PKGVER@
+pkgrel=1
+pkgdesc="Attach remote ESP32 Bluetooth bridges to the local Bluetooth stack (release binary)"
+arch=('x86_64' 'aarch64' 'armv7h')
+url="https://github.com/heppu/esp-hci-bridge"
+license=('MIT')
+depends=('bluez')
+provides=('hcibridge')
+conflicts=('hcibridge')
+backup=('etc/hcibridge/config' 'etc/hcibridge/config.d/50-example.conf' 'etc/default/hcibridge')
+_rel="https://github.com/heppu/esp-hci-bridge/releases/download/v$pkgver"
+source=("hcibridge-$pkgver.tar.gz::https://github.com/heppu/esp-hci-bridge/archive/refs/tags/v$pkgver.tar.gz"
+        "hcibridge.1-$pkgver::$_rel/hcibridge.1"
+        "hcibridge.bash-$pkgver::$_rel/hcibridge.bash"
+        "_hcibridge-$pkgver::$_rel/_hcibridge"
+        "hcibridge.fish-$pkgver::$_rel/hcibridge.fish")
+source_x86_64=("hcibridge-$pkgver-x86_64::$_rel/hcibridge-x86_64-linux")
+source_aarch64=("hcibridge-$pkgver-aarch64::$_rel/hcibridge-aarch64-linux")
+source_armv7h=("hcibridge-$pkgver-armv7h::$_rel/hcibridge-armv7-linux")
+sha256sums=('@SHA256@' '@SHA_MAN@' '@SHA_BASH@' '@SHA_ZSH@' '@SHA_FISH@')
+sha256sums_x86_64=('@SHA_X86_64@')
+sha256sums_aarch64=('@SHA_AARCH64@')
+sha256sums_armv7h=('@SHA_ARMV7@')
+
+package() {
+    local src="esp-hci-bridge-$pkgver"
+    install -Dm755 "hcibridge-$pkgver-$CARCH" "$pkgdir/usr/bin/hcibridge"
+    install -Dm644 "hcibridge.1-$pkgver" "$pkgdir/usr/share/man/man1/hcibridge.1"
+    install -Dm644 "hcibridge.bash-$pkgver" "$pkgdir/usr/share/bash-completion/completions/hcibridge"
+    install -Dm644 "_hcibridge-$pkgver" "$pkgdir/usr/share/zsh/site-functions/_hcibridge"
+    install -Dm644 "hcibridge.fish-$pkgver" "$pkgdir/usr/share/fish/vendor_completions.d/hcibridge.fish"
+    install -Dm644 "$src/host/systemd/hcibridge.service" "$pkgdir/usr/lib/systemd/system/hcibridge.service"
+    install -Dm644 "$src/host/systemd/hcibridge.env" "$pkgdir/etc/default/hcibridge"
+    install -Dm644 "$src/host/modules-load.conf" "$pkgdir/usr/lib/modules-load.d/hci_vhci.conf"
+    install -Dm644 "$src/host/config/config" "$pkgdir/etc/hcibridge/config"
+    install -Dm644 "$src/host/config/config.d/50-example.conf" "$pkgdir/etc/hcibridge/config.d/50-example.conf"
+    install -Dm644 "$src/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/packaging/verify-recipes.sh
+++ b/packaging/verify-recipes.sh
@@ -22,7 +22,12 @@ docker run --rm -v "$DIR:/in:ro" archlinux:latest bash -euc '
   useradd -m b && mkdir /b && cp /in/PKGBUILD /b/ && chown -R b /b
   su b -c "cd /b && makepkg --noconfirm >/dev/null 2>&1"
   pacman -U --noconfirm /b/hcibridge-[0-9]*-x86_64.pkg.tar.zst >/dev/null 2>&1
-  echo "installed: $(hcibridge --version)"' | check
+  echo "installed: $(hcibridge --version)"
+  # the -bin package replaces the source one, conflicts declared
+  mkdir /bb && cp /in/PKGBUILD-bin /bb/PKGBUILD && chown -R b /bb
+  su b -c "cd /bb && makepkg --noconfirm >/dev/null 2>&1"
+  pacman -U --noconfirm /bb/hcibridge-bin-[0-9]*-x86_64.pkg.tar.zst >/dev/null 2>&1
+  echo "installed-bin: $(hcibridge --version)"' | check
 # The same package under a real systemd, CI only: privileged systemd
 # containers are not safe on a workstation.
 if [ "${CI:-}" = true ]; then
@@ -57,12 +62,14 @@ want void && { echo "== void (xbps-src)"
 # Void's own CI recipe for running xbps-src as root in a container.
 docker run --rm --privileged -v "$DIR:/in:ro" ghcr.io/void-linux/void-buildroot-glibc:latest sh -euc '
   xbps-install -Sy git >/dev/null 2>&1
-  cd /tmp && git clone -q --depth 1 https://github.com/void-linux/void-packages.git && cd void-packages
+  cd /tmp && echo "clone start $(date +%T)" && git clone -q --depth 1 https://github.com/void-linux/void-packages.git && cd void-packages && echo "clone done $(date +%T)"
   echo XBPS_CHROOT_CMD=ethereal >> etc/conf
   echo XBPS_ALLOW_CHROOT_BREAKOUT=yes >> etc/conf
   ln -s / masterdir
   mkdir -p srcpkgs/hcibridge && cp /in/void-template srcpkgs/hcibridge/template
+  echo "build start $(date +%T)"
   ./xbps-src pkg hcibridge >/dev/null 2>&1 || ./xbps-src pkg hcibridge 2>&1 | tail -15
+  echo "build done $(date +%T)"
   xbps-rindex -a hostdir/binpkgs/*.xbps >/dev/null 2>&1
   xbps-install -Sy --repository=hostdir/binpkgs hcibridge >/dev/null 2>&1
   echo "installed: $(hcibridge --version)"' | check; }

--- a/packaging/verify-repos.sh
+++ b/packaging/verify-repos.sh
@@ -25,7 +25,8 @@ boot() {
     [ "${CI:-}" = true ] || { echo "skipping systemd container $name: only allowed in CI (set CI=true on a disposable VM)"; return 1; }
     docker rm -f "$name" >/dev/null 2>&1 || true
     docker run -d --name "$name" --privileged --cgroupns=host -v /sys/fs/cgroup:/sys/fs/cgroup:rw --network host -v "$REPO:/repo:ro" "$@" >/dev/null
-    docker exec "$name" sh -c 'for i in $(seq 1 60); do systemctl is-system-running 2>/dev/null | grep -Eq "running|degraded" && exit 0; sleep 1; done; echo "systemd did not come up" >&2; exit 1'
+    # The images install systemd first, so allow a few minutes before init answers.
+    docker exec "$name" sh -c 'for i in $(seq 1 300); do systemctl is-system-running 2>/dev/null | grep -Eq "running|degraded" && exit 0; sleep 1; done; echo "systemd did not come up" >&2; exit 1' || { docker logs "$name" 2>&1 | tail -5; docker rm -f "$name" >/dev/null 2>&1; return 1; }
 }
 check() {
     got=$(cat)
@@ -57,7 +58,7 @@ docker rm -f vr-debian >/dev/null
 fi
 
 echo "== fedora"
-if boot vr-fedora fedora:latest /sbin/init; then
+if boot vr-fedora fedora:latest sh -c 'dnf -q install -y systemd >/dev/null 2>&1 && exec /sbin/init'; then
 docker exec vr-fedora sh -euc "
   if curl -sf -o /etc/yum.repos.d/hcibridge-live.repo $LIVE/rpm/hcibridge.repo; then
     sed -i 's/^\[hcibridge\]/[hcibridge-live]/' /etc/yum.repos.d/hcibridge-live.repo


### PR DESCRIPTION
- `hcibridge-bin` on the AUR: a PKGBUILD that installs the static release binary, man page, completions, and the config and unit files from the source tarball, every asset pinned by sha256. Rendered in the release, pushed to the AUR next to `hcibridge`, and built plus installed in the Arch recipe check.
- The Debian and Fedora systemd checks never ran in v0.10.17: Fedora's image has no systemd, and Debian was still installing it when the 60 s wait gave up. Both images now install systemd before init and the wait is five minutes, with container logs on failure.
- Timing lines in the Void recipe check, it took 23 minutes in v0.10.17 for no visible reason.