### PR TITLE
Verify the package repositories and service start in CI for packaging changes, fix the Debian and Fedora systemd containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
           tar xzf nfpm.tgz nfpm && rm nfpm.tgz
           mkdir -p dist && cp zig-out/bin/hcibridge dist/hcibridge
           openssl genrsa -out packaging/keys/heppu-esp-hci-bridge.rsa 2048 2>/dev/null
+          openssl rsa -in packaging/keys/heppu-esp-hci-bridge.rsa -pubout -out packaging/keys/heppu-esp-hci-bridge.rsa.pub 2>/dev/null
           gpg --batch --quick-gen-key --passphrase '' ci@example.invalid rsa2048 sign 0 2>/dev/null
           gpg --batch --armor --export-secret-keys ci@example.invalid > packaging/keys/hcibridge.gpg
           mkdir -p pkgs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           version: 0.16.0
       - run: zig fmt --check build.zig common host firmware/main
       - run: zig build test --summary all
-      - run: zig build -Doptimize=ReleaseSafe
+      - run: zig build -Doptimize=ReleaseSafe -Dversion=v99.0.0
       - run: zig build release
       - run: zig build gen
       - name: Check generated completions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       firmware: ${{ steps.f.outputs.firmware }}
+      packaging: ${{ steps.f.outputs.packaging }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad # v3
@@ -28,8 +29,16 @@ jobs:
               - 'common/**'
               - 'scripts/firmware.sh'
               - '.github/workflows/ci.yml'
+            packaging:
+              - 'packaging/**'
+              - 'host/systemd/**'
+              - 'host/openrc/**'
+              - 'host/runit/**'
+              - 'host/config/**'
+              - '.github/workflows/ci.yml'
 
   host:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -58,8 +67,19 @@ jobs:
           openssl genrsa -out packaging/keys/heppu-esp-hci-bridge.rsa 2048 2>/dev/null
           gpg --batch --quick-gen-key --passphrase '' ci@example.invalid rsa2048 sign 0 2>/dev/null
           gpg --batch --armor --export-secret-keys ci@example.invalid > packaging/keys/hcibridge.gpg
-          for fmt in deb rpm apk; do PKG_ARCH=amd64 VERSION=0.0.0 ./nfpm pkg -f packaging/nfpm.yaml -p $fmt -t .; done
-          ls -1 *.deb *.rpm *.apk
+          mkdir -p pkgs
+          PKG_ARCH=amd64 VERSION=99.0.0 ./nfpm pkg -f packaging/nfpm.yaml -p deb -t pkgs/
+          PKG_ARCH=x86_64 VERSION=99.0.0 ./nfpm pkg -f packaging/nfpm.yaml -p rpm -t pkgs/
+          PKG_ARCH=x86_64 VERSION=99.0.0 ./nfpm pkg -f packaging/nfpm.yaml -p apk -t pkgs/
+          ls -1 pkgs
+      # Only when packaging changed: build the three repositories with the
+      # throwaway keys and install from them, service start included.
+      - name: Repositories and installs in containers
+        if: needs.changes.outputs.packaging == 'true'
+        run: |
+          sudo apt-get -qq update >/dev/null && sudo apt-get -qq install -y dpkg-dev apt-utils createrepo-c gnupg >/dev/null
+          packaging/make-repos.sh pkgs repo packaging/keys
+          packaging/verify-repos.sh repo v99.0.0
 
   firmware:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
           openssl rsa -in packaging/keys/heppu-esp-hci-bridge.rsa -pubout -out packaging/keys/heppu-esp-hci-bridge.rsa.pub 2>/dev/null
           gpg --batch --quick-gen-key --passphrase '' ci@example.invalid rsa2048 sign 0 2>/dev/null
           gpg --batch --armor --export-secret-keys ci@example.invalid > packaging/keys/hcibridge.gpg
+          gpg --batch --armor --export ci@example.invalid > packaging/keys/hcibridge.gpg.pub
           mkdir -p pkgs
           PKG_ARCH=amd64 VERSION=99.0.0 ./nfpm pkg -f packaging/nfpm.yaml -p deb -t pkgs/
           PKG_ARCH=x86_64 VERSION=99.0.0 ./nfpm pkg -f packaging/nfpm.yaml -p rpm -t pkgs/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,29 +161,7 @@ jobs:
               -e "s/@SHA_ARMV7@/$(h hcibridge-armv7-linux)/" packaging/PKGBUILD-bin.tmpl > out/PKGBUILD-bin
           sed -e "s/@PKGVER@/$VER/" -e "s/@SHA256@/$SHA/" packaging/void-template.tmpl > out/void-template
           ls -1 out/
-      - name: Build the Alpine repository
-        run: |
-          set -eu
-          VER="${GITHUB_REF_NAME#v}"
-          KEY=heppu-esp-hci-bridge
-          mkdir -p repo/alpine
-          cp packaging/keys/$KEY.rsa.pub repo/alpine/
-          for arch in x86_64 aarch64 armv7; do
-            mkdir -p "repo/alpine/$arch"
-            # apk fetches <name>-<version>.apk, whatever the file was called at build time
-            cp "out/hcibridge_${VER}_${arch}.apk" "repo/alpine/$arch/hcibridge-${VER}.apk"
-          done
-          docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp -v "$PWD/repo/alpine:/r" -v "$PWD/packaging/keys:/keys:ro" alpine:3.22 \
-            sh -c 'for d in /r/*/; do cd "$d" && apk index --keys-dir /keys -o unsigned.tar.gz *.apk; done'
-          # abuild-sign without abuild: RSA-SHA1 over the index, prepended as its own tar
-          for d in repo/alpine/*/; do
-            ( cd "$d"
-              openssl dgst -sha1 -sign "$OLDPWD/packaging/keys/$KEY.rsa" -out ".SIGN.RSA.$KEY.rsa.pub" unsigned.tar.gz
-              tar -c --owner=0 --group=0 --numeric-owner ".SIGN.RSA.$KEY.rsa.pub" | head -c 1536 | gzip -9 > sig.tar.gz
-              cat sig.tar.gz unsigned.tar.gz > APKINDEX.tar.gz
-              rm -f sig.tar.gz unsigned.tar.gz ".SIGN.RSA.$KEY.rsa.pub" )
-          done
-      - name: Build the apt and rpm repositories
+      - name: Build the package repositories
         run: |
           sudo apt-get -qq update >/dev/null && sudo apt-get -qq install -y dpkg-dev apt-utils createrepo-c gnupg >/dev/null
           packaging/make-repos.sh out repo packaging/keys

--- a/packaging/make-repos.sh
+++ b/packaging/make-repos.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
-# Builds the apt and rpm repositories from a directory of packages.
+# Builds the apt, rpm, and apk repositories from a directory of packages.
 # Usage: packaging/make-repos.sh <packages dir> <repo dir> <keys dir>
-# Needs dpkg-scanpackages, apt-ftparchive, createrepo_c, gpg. The apk
-# repository is built by the release workflow with apk-tools.
+# Needs dpkg-scanpackages, apt-ftparchive, createrepo_c, gpg, openssl, and
+# docker for apk-tools.
 set -eu
 PKGS=$1
 REPO=$2
@@ -60,5 +60,29 @@ gpgcheck=1
 repo_gpgcheck=1
 gpgkey=$SITE/hcibridge.gpg.pub
 EOF
+
+# apk: one directory per arch, index signed the way abuild-sign does it
+AKEY=heppu-esp-hci-bridge
+APK="$REPO/alpine"
+mkdir -p "$APK"
+cp "$KEYS/$AKEY.rsa.pub" "$APK/"
+for f in "$PKGS"/hcibridge_*_*.apk; do
+    [ -f "$f" ] || continue
+    base=$(basename "$f" .apk)
+    ver=${base#hcibridge_}; ver=${ver%_*}
+    arch=${base##*_}
+    mkdir -p "$APK/$arch"
+    # apk fetches <name>-<version>.apk, whatever the file was called at build time
+    cp "$f" "$APK/$arch/hcibridge-$ver.apk"
+done
+docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp -v "$(cd "$APK" && pwd):/r" -v "$(cd "$KEYS" && pwd):/keys:ro" alpine:3.22 \
+    sh -c 'for d in /r/*/; do cd "$d" && apk index --keys-dir /keys -o unsigned.tar.gz *.apk; done'
+for d in "$APK"/*/; do
+    ( cd "$d"
+      openssl dgst -sha1 -sign "$OLDPWD/$KEYS/$AKEY.rsa" -out ".SIGN.RSA.$AKEY.rsa.pub" unsigned.tar.gz
+      tar -c --owner=0 --group=0 --numeric-owner ".SIGN.RSA.$AKEY.rsa.pub" | head -c 1536 | gzip -9 > sig.tar.gz
+      cat sig.tar.gz unsigned.tar.gz > APKINDEX.tar.gz
+      rm -f sig.tar.gz unsigned.tar.gz ".SIGN.RSA.$AKEY.rsa.pub" )
+done
 
 find "$REPO" -type f | sort

--- a/packaging/make-repos.sh
+++ b/packaging/make-repos.sh
@@ -69,8 +69,14 @@ cp "$KEYS/$AKEY.rsa.pub" "$APK/"
 for f in "$PKGS"/hcibridge_*_*.apk; do
     [ -f "$f" ] || continue
     base=$(basename "$f" .apk)
-    ver=${base#hcibridge_}; ver=${ver%_*}
-    arch=${base##*_}
+    # hcibridge_<ver>_<arch>.apk, and x86_64 has its own underscore
+    case "$base" in
+        *_x86_64) arch=x86_64 ;;
+        *_aarch64) arch=aarch64 ;;
+        *_armv7) arch=armv7 ;;
+        *) echo "unknown apk arch in $base" >&2; exit 1 ;;
+    esac
+    ver=${base#hcibridge_}; ver=${ver%_$arch}
     mkdir -p "$APK/$arch"
     # apk fetches <name>-<version>.apk, whatever the file was called at build time
     cp "$f" "$APK/$arch/hcibridge-$ver.apk"

--- a/packaging/verify-repos.sh
+++ b/packaging/verify-repos.sh
@@ -38,7 +38,7 @@ check() {
 LIVE=https://heppu.github.io/esp-hci-bridge
 
 echo "== debian"
-if boot vr-debian -e DEBIAN_FRONTEND=noninteractive debian:stable-slim sh -c 'apt-get -qq update >/dev/null && apt-get -qq install -y systemd ca-certificates curl >/dev/null && exec /sbin/init'; then
+if boot vr-debian -e DEBIAN_FRONTEND=noninteractive debian:stable-slim sh -c 'apt-get -qq update >/dev/null && apt-get -qq install -y systemd ca-certificates curl >/dev/null && exec /lib/systemd/systemd'; then
 docker exec vr-debian sh -euc "
   mkdir -p /etc/apt/keyrings
   install -m 644 /repo/hcibridge.gpg /etc/apt/keyrings/hcibridge.gpg
@@ -66,7 +66,8 @@ docker exec vr-fedora sh -euc "
     rm -f /etc/yum.repos.d/hcibridge-live.repo
   fi
   sed \"s|$LIVE|$URL|\" /repo/rpm/hcibridge.repo > /etc/yum.repos.d/hcibridge.repo
-  dnf -q install -y hcibridge >/dev/null 2>&1 || dnf -q upgrade -y hcibridge >/dev/null
+  dnf -y install hcibridge 2>&1 | tail -n 3
+  dnf -y upgrade hcibridge 2>&1 | tail -n 1
   echo \"installed: \$(hcibridge --version)\"
   sleep 2
   echo \"service: \$(systemctl is-active hcibridge)\"

--- a/packaging/verify-repos.sh
+++ b/packaging/verify-repos.sh
@@ -60,6 +60,9 @@ fi
 echo "== fedora"
 if boot vr-fedora fedora:latest sh -c 'dnf -q install -y systemd >/dev/null 2>&1 && exec /sbin/init'; then
 docker exec vr-fedora sh -euc "
+  # systemd-resolved's stub resolver does not work inside the container
+  systemctl disable --now systemd-resolved >/dev/null 2>&1 || true
+  rm -f /etc/resolv.conf && printf 'nameserver 1.1.1.1\\nnameserver 8.8.8.8\\n' > /etc/resolv.conf
   if curl -sf -o /etc/yum.repos.d/hcibridge-live.repo $LIVE/rpm/hcibridge.repo; then
     sed -i 's/^\[hcibridge\]/[hcibridge-live]/' /etc/yum.repos.d/hcibridge-live.repo
     dnf -q install -y hcibridge >/dev/null 2>&1 && echo \"previous: \$(hcibridge --version)\" || echo 'previous: none'

--- a/packaging/verify-repos.sh
+++ b/packaging/verify-repos.sh
@@ -62,7 +62,7 @@ if boot vr-fedora fedora:latest sh -c 'dnf -q install -y systemd >/dev/null 2>&1
 docker exec vr-fedora sh -euc "
   # systemd-resolved's stub resolver does not work inside the container
   systemctl disable --now systemd-resolved >/dev/null 2>&1 || true
-  rm -f /etc/resolv.conf && printf 'nameserver 1.1.1.1\\nnameserver 8.8.8.8\\n' > /etc/resolv.conf
+  printf 'nameserver 1.1.1.1\\nnameserver 8.8.8.8\\n' > /etc/resolv.conf
   if curl -sf -o /etc/yum.repos.d/hcibridge-live.repo $LIVE/rpm/hcibridge.repo; then
     sed -i 's/^\[hcibridge\]/[hcibridge-live]/' /etc/yum.repos.d/hcibridge-live.repo
     dnf -q install -y hcibridge >/dev/null 2>&1 && echo \"previous: \$(hcibridge --version)\" || echo 'previous: none'


### PR DESCRIPTION
v0.10.19 failed its release on the systemd checks and left a dead tag. Fixes:
- Debian: the `systemd` package does not ship `/sbin/init`, start `/lib/systemd/systemd` directly.
- Fedora: the failing dnf install was silenced by `-q`, its output is shown now.
- The apk repository build moves from the release workflow into `packaging/make-repos.sh`, so one script builds all three repositories.
- CI builds the three repositories with throwaway keys and runs the same container installs, service start included, on any PR that touches packaging, service files, or config. Version 99.0.0 so the upgrade from the live repository actually upgrades. Release-only iteration on this is over.