### PR TITLE
Alpine uses doas, not sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ services are never started by packages.
 Alpine:
 
 ```sh
-sudo wget -O /etc/apk/keys/heppu-esp-hci-bridge.rsa.pub https://heppu.github.io/esp-hci-bridge/alpine/heppu-esp-hci-bridge.rsa.pub
-echo https://heppu.github.io/esp-hci-bridge/alpine | sudo tee -a /etc/apk/repositories
-sudo apk add hcibridge
+doas wget -O /etc/apk/keys/heppu-esp-hci-bridge.rsa.pub https://heppu.github.io/esp-hci-bridge/alpine/heppu-esp-hci-bridge.rsa.pub
+echo https://heppu.github.io/esp-hci-bridge/alpine | doas tee -a /etc/apk/repositories
+doas apk add hcibridge
 ```
 
 Arch:

--- a/web/index.html
+++ b/web/index.html
@@ -103,9 +103,9 @@
     <li><button role="tab" aria-selected="false" data-tab="other">Other</button></li>
   </ul>
   <div class="panel" data-panel="apk">
-<pre><code>sudo wget -O /etc/apk/keys/heppu-esp-hci-bridge.rsa.pub https://heppu.github.io/esp-hci-bridge/alpine/heppu-esp-hci-bridge.rsa.pub
-echo https://heppu.github.io/esp-hci-bridge/alpine | sudo tee -a /etc/apk/repositories
-sudo apk add hcibridge</code></pre>
+<pre><code>doas wget -O /etc/apk/keys/heppu-esp-hci-bridge.rsa.pub https://heppu.github.io/esp-hci-bridge/alpine/heppu-esp-hci-bridge.rsa.pub
+echo https://heppu.github.io/esp-hci-bridge/alpine | doas tee -a /etc/apk/repositories
+doas apk add hcibridge</code></pre>
     <p class="meta">A signed repository for <code>x86_64</code>, <code>aarch64</code>, and <code>armv7</code>. <code>apk upgrade</code> picks up new releases. The service is <code>hcibridged</code> under OpenRC.</p>
   </div>
   <div class="panel" data-panel="arch" hidden>


### PR DESCRIPTION
Alpine ships doas, the README and site said sudo.