### PR TITLE
Take the version from build.zig.zon and release on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,34 @@ jobs:
               - 'host/config/**'
               - '.github/workflows/ci.yml'
 
+  versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - run: scripts/check-versions.sh
+      # A merge to main with a bumped version releases it, so the bump has to
+      # be releasable before it lands.
+      - name: A version bump must be new and higher
+        if: github.event_name == 'pull_request'
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+        run: |
+          ver() { sed -n 's/^[[:space:]]*\.version = "\([^"]*\)".*/\1/p' "$1"; }
+          new=$(ver build.zig.zon)
+          git show "$BASE:build.zig.zon" > base.zon
+          old=$(ver base.zon)
+          rm -f base.zon
+          if [ "$new" = "$old" ]; then echo "version unchanged at $old"; exit 0; fi
+          echo "version $old -> $new"
+          [ "$(printf '%s\n%s\n' "$old" "$new" | sort -V | tail -1)" = "$new" ] \
+            || { echo "$new is not higher than $old"; exit 1; }
+          if git ls-remote --exit-code --tags origin "refs/tags/v$new" >/dev/null 2>&1; then
+            echo "v$new is already tagged, merging this would release nothing"
+            exit 1
+          fi
+
   host:
     needs: changes
     runs-on: ubuntu-latest
@@ -48,6 +76,13 @@ jobs:
       - run: zig fmt --check build.zig common host firmware/main
       - run: zig build test --summary all
       - run: zig build -Doptimize=ReleaseSafe -Dversion=v99.0.0
+      # Its own prefix: zig-out holds the v99.0.0 build the packages are made from.
+      - name: The default build takes its version from build.zig.zon
+        run: |
+          zig build --prefix zig-out-default
+          want="hcibridge v$(sed -n 's/^[[:space:]]*\.version = "\([^"]*\)".*/\1/p' build.zig.zon)"
+          got=$(./zig-out-default/bin/hcibridge --version)
+          [ "$got" = "$want" ] || { echo "binary says \"$got\", build.zig.zon says \"$want\""; exit 1; }
       - run: zig build release
       - run: zig build gen
       - name: Check generated completions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,54 @@
 name: release
 
+# A release is a commit: bump .version in build.zig.zon, merge to main, and
+# this workflow tags that commit and publishes it. Commits that do not change
+# the version stop after the version job.
 on:
   push:
-    tags: ["v*"]
+    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
+# Two releases must never interleave: the second would tag while the first is
+# still publishing.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      tag: ${{ steps.v.outputs.tag }}
+      release: ${{ steps.v.outputs.release }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - id: v
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VER=$(sed -n 's/^[[:space:]]*\.version = "\([^"]*\)".*/\1/p' build.zig.zon)
+          echo "$VER" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' || { echo "build.zig.zon .version is \"$VER\""; exit 1; }
+          {
+            echo "version=$VER"
+            echo "tag=v$VER"
+          } >> "$GITHUB_OUTPUT"
+          # Gated on the release, not on the tag: a run that failed after
+          # tagging can be re-run and will finish the job.
+          if gh release view "v$VER" >/dev/null 2>&1; then
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            echo "v$VER is already released, nothing to do"
+          else
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            echo "releasing v$VER"
+          fi
+
   firmware:
+    needs: version
+    if: needs.version.outputs.release == 'true'
     runs-on: ubuntu-latest
     container:
       image: espressif/idf:v5.5.5@sha256:a9231d0697ab8f7517cc072e93b7c83e04907bfbfba80b6440d7dbbf90665cf2
@@ -38,11 +78,6 @@ jobs:
           curl -sSL -o zig-xtensa.tar.xz https://github.com/kassane/zig-espressif-bootstrap/releases/download/0.16.0-xtensa/zig-relsafe-x86_64-linux-musl-baseline.tar.xz
           echo "9e3dcef9d6f6d552df641a12addc9e443a69b7cbdad85492ec677acd55b7de9b  zig-xtensa.tar.xz" | sha256sum -c -
           tar -xJ -C .tools/zig-xtensa --strip-components=1 -f zig-xtensa.tar.xz && rm zig-xtensa.tar.xz
-      - name: Tag must be on main
-        run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git fetch --no-tags --depth=200 origin main
-          git merge-base --is-ancestor "$GITHUB_SHA" origin/main || { echo "tag $GITHUB_REF_NAME is not on main"; exit 1; }
       - name: Release signing key
         env:
           KEY: ${{ secrets.FIRMWARE_SIGNING_KEY }}
@@ -51,10 +86,11 @@ jobs:
           printf '%s\n' "$KEY" > firmware/secure_boot_signing_key.pem
       - name: Build ${{ matrix.board }}
         shell: bash
+        env:
+          PROJECT_VER: ${{ needs.version.outputs.tag }}
         run: |
           . /opt/esp/idf/export.sh
           export ZIG="$PWD/.tools/zig-xtensa/zig"
-          export PROJECT_VER="${GITHUB_REF_NAME}"
           cd firmware
           B="build-${{ matrix.board }}"
           idf.py -B "$B" -DSDKCONFIG="$B/sdkconfig" \
@@ -73,33 +109,11 @@ jobs:
           name: fw-${{ matrix.board }}
           path: fw/
 
-  site:
-    needs: [firmware, cli]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: fw-*
-          path: fw
-          merge-multiple: true
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: pkg-repos
-          path: repo
-      - name: Assemble site for all boards
-        run: |
-          scripts/make-site.sh "${GITHUB_REF_NAME}" _site \
-            olimex-esp32-poe=fw/olimex-esp32-poe \
-            wt32-eth01=fw/wt32-eth01 \
-            generic-wifi=fw/generic-wifi
-          cp -r repo/alpine repo/deb repo/rpm repo/hcibridge.gpg repo/hcibridge.gpg.pub _site/
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: site
-          path: _site
-
+  # Binaries, packages, and the signed repositories. None of this needs the
+  # tag to exist, so it all runs before the tag is pushed.
   cli:
+    needs: version
+    if: needs.version.outputs.release == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -107,9 +121,14 @@ jobs:
         with:
           version: 0.16.0
       - run: zig build test --summary all
-      - run: zig build release -Dversion="${GITHUB_REF_NAME}"
+      - run: zig build release
       - name: Generate man page and completions
-        run: zig build gen -Dversion="${GITHUB_REF_NAME}"
+        run: zig build gen
+      - name: The binary must report the version being released
+        run: |
+          zig build --prefix check
+          got=$(./check/bin/hcibridge --version)
+          [ "$got" = "hcibridge ${{ needs.version.outputs.tag }}" ] || { echo "binary says \"$got\""; exit 1; }
       - name: Package signing keys
         env:
           KEY: ${{ secrets.APK_SIGNING_KEY }}
@@ -126,12 +145,12 @@ jobs:
           echo "1a12d47f104bdd5953d33bb1e97b369ffade9c429bfc070fd19977844100d3d2  nfpm.tgz" | sha256sum -c -
           tar xzf nfpm.tgz nfpm && rm nfpm.tgz
           sudo install nfpm /usr/local/bin/nfpm
-      - name: Build packages and metadata
+      - name: Build packages
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
         run: |
           set -eu
           mkdir -p out
-          VER="${GITHUB_REF_NAME#v}"
-          export VERSION="$VER"
           cp zig-out/x86_64-linux-musl/hcibridge   out/hcibridge-x86_64-linux
           cp zig-out/aarch64-linux-musl/hcibridge  out/hcibridge-aarch64-linux
           cp zig-out/arm-linux-musleabihf/hcibridge out/hcibridge-armv7-linux
@@ -146,27 +165,13 @@ jobs:
               PKG_ARCH="$arch" nfpm pkg -f packaging/nfpm.yaml -p "$fmt" -t out/
             done
           done
-          # AUR PKGBUILD, Alpine APKBUILD and Void template with version + source checksum
-          curl -sSfL -o src.tar.gz "https://github.com/heppu/hcibridge/archive/refs/tags/${GITHUB_REF_NAME}.tar.gz"
-          SHA=$(sha256sum src.tar.gz | cut -d' ' -f1)
-          SHA512=$(sha512sum src.tar.gz | cut -d' ' -f1)
-          sed -e "s/@PKGVER@/$VER/" -e "s/@SHA256@/$SHA/" packaging/PKGBUILD.tmpl > out/PKGBUILD
-          sed -e "s/@PKGVER@/$VER/" -e "s/@SHA512@/$SHA512/" packaging/APKBUILD.tmpl > out/APKBUILD
-          # the -bin PKGBUILD pins every release asset it downloads
-          h() { sha256sum "out/$1" | cut -d' ' -f1; }
-          sed -e "s/@PKGVER@/$VER/" -e "s/@SHA256@/$SHA/" \
-              -e "s/@SHA_MAN@/$(h hcibridge.1)/" -e "s/@SHA_BASH@/$(h hcibridge.bash)/" \
-              -e "s/@SHA_ZSH@/$(h _hcibridge)/" -e "s/@SHA_FISH@/$(h hcibridge.fish)/" \
-              -e "s/@SHA_X86_64@/$(h hcibridge-x86_64-linux)/" -e "s/@SHA_AARCH64@/$(h hcibridge-aarch64-linux)/" \
-              -e "s/@SHA_ARMV7@/$(h hcibridge-armv7-linux)/" packaging/PKGBUILD-bin.tmpl > out/PKGBUILD-bin
-          sed -e "s/@PKGVER@/$VER/" -e "s/@SHA256@/$SHA/" packaging/void-template.tmpl > out/void-template
           ls -1 out/
       - name: Build the package repositories
         run: |
           sudo apt-get -qq update >/dev/null && sudo apt-get -qq install -y dpkg-dev apt-utils createrepo-c gnupg >/dev/null
           packaging/make-repos.sh out repo packaging/keys
       - name: Install from every repository in a container
-        run: packaging/verify-repos.sh repo "${GITHUB_REF_NAME}"
+        run: packaging/verify-repos.sh repo "${{ needs.version.outputs.tag }}"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cli
@@ -176,9 +181,98 @@ jobs:
           name: pkg-repos
           path: repo/
 
-  # The source recipes on the release page, built the way each distro builds them.
+  site:
+    needs: [version, firmware, cli]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: fw-*
+          path: fw
+          merge-multiple: true
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pkg-repos
+          path: repo
+      - name: Assemble site for all boards
+        run: |
+          scripts/make-site.sh "${{ needs.version.outputs.tag }}" _site \
+            olimex-esp32-poe=fw/olimex-esp32-poe \
+            wt32-eth01=fw/wt32-eth01 \
+            generic-wifi=fw/generic-wifi
+          cp -r repo/alpine repo/deb repo/rpm repo/hcibridge.gpg repo/hcibridge.gpg.pub _site/
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: site
+          path: _site
+
+  # The last cheap place to fail. Everything above is built and installed in
+  # containers before this commit gets a tag anyone can see.
+  tag:
+    needs: [version, firmware, cli, site]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Tag ${{ needs.version.outputs.tag }}
+        env:
+          TAG: ${{ needs.version.outputs.tag }}
+        run: |
+          have=$(git ls-remote --tags origin "refs/tags/$TAG" | cut -f1)
+          if [ -n "$have" ]; then
+            [ "$have" = "$GITHUB_SHA" ] || { echo "$TAG already points at $have, not $GITHUB_SHA"; exit 1; }
+            echo "$TAG already on this commit, re-running a failed release"
+            exit 0
+          fi
+          git tag "$TAG"
+          git push origin "$TAG"
+
+  # The source recipes carry the checksum of the GitHub source tarball, which
+  # only exists once the tag does.
   recipes:
-    needs: cli
+    needs: [version, tag]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: cli
+          path: cli
+      - name: Render the AUR, Alpine, and Void recipes
+        env:
+          VER: ${{ needs.version.outputs.version }}
+          TAG: ${{ needs.version.outputs.tag }}
+        run: |
+          set -eu
+          mkdir -p out
+          # The tarball is generated on demand, so give it a moment to appear.
+          for i in 1 2 3 4 5; do
+            curl -sSfL -o src.tar.gz "https://github.com/heppu/hcibridge/archive/refs/tags/$TAG.tar.gz" && break
+            echo "attempt $i: source tarball not ready"; sleep 5
+          done
+          SHA=$(sha256sum src.tar.gz | cut -d' ' -f1)
+          SHA512=$(sha512sum src.tar.gz | cut -d' ' -f1)
+          sed -e "s/@PKGVER@/$VER/" -e "s/@SHA256@/$SHA/" packaging/PKGBUILD.tmpl > out/PKGBUILD
+          sed -e "s/@PKGVER@/$VER/" -e "s/@SHA512@/$SHA512/" packaging/APKBUILD.tmpl > out/APKBUILD
+          # the -bin PKGBUILD pins every release asset it downloads
+          h() { sha256sum "cli/$1" | cut -d' ' -f1; }
+          sed -e "s/@PKGVER@/$VER/" -e "s/@SHA256@/$SHA/" \
+              -e "s/@SHA_MAN@/$(h hcibridge.1)/" -e "s/@SHA_BASH@/$(h hcibridge.bash)/" \
+              -e "s/@SHA_ZSH@/$(h _hcibridge)/" -e "s/@SHA_FISH@/$(h hcibridge.fish)/" \
+              -e "s/@SHA_X86_64@/$(h hcibridge-x86_64-linux)/" -e "s/@SHA_AARCH64@/$(h hcibridge-aarch64-linux)/" \
+              -e "s/@SHA_ARMV7@/$(h hcibridge-armv7-linux)/" packaging/PKGBUILD-bin.tmpl > out/PKGBUILD-bin
+          sed -e "s/@PKGVER@/$VER/" -e "s/@SHA256@/$SHA/" packaging/void-template.tmpl > out/void-template
+          ls -1 out/
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: recipes
+          path: out/
+
+  # The source recipes, built the way each distro builds them.
+  recipe-check:
+    needs: [version, recipes]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -189,10 +283,14 @@ jobs:
         with:
           name: cli
           path: cli
-      - run: packaging/verify-recipes.sh cli "${GITHUB_REF_NAME}" ${{ matrix.distro }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: recipes
+          path: cli
+      - run: packaging/verify-recipes.sh cli "${{ needs.version.outputs.tag }}" ${{ matrix.distro }}
 
   release:
-    needs: [site, cli, recipes]
+    needs: [version, site, cli, recipes, recipe-check]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -207,7 +305,13 @@ jobs:
         with:
           name: cli
           path: cli
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: recipes
+          path: cli
       - name: Assemble assets
+        env:
+          VER: ${{ needs.version.outputs.version }}
         run: |
           mkdir -p release
           # app image and bootloader differ per board, partition table and OTA data do not
@@ -222,7 +326,6 @@ jobs:
           cp cli/* release/
           chmod +x release/hcibridge-*
           # versionless copies so releases/latest/download/<file> always resolves
-          VER="${GITHUB_REF_NAME#v}"
           for f in release/hcibridge_"$VER"_*.deb release/hcibridge_"$VER"_*.apk; do
             cp "$f" "${f/_${VER}_/_}"
           done
@@ -235,18 +338,19 @@ jobs:
           subject-path: release/*
       - uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
+          tag_name: ${{ needs.version.outputs.tag }}
           files: release/*
           fail_on_unmatched_files: true
           generate_release_notes: true
 
   # Keeps aur.archlinux.org/packages/hcibridge on the released version.
   aur:
-    needs: release
+    needs: [version, release]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: cli
+          name: recipes
           path: cli
       - name: Generate .SRCINFO for both packages
         run: |
@@ -261,6 +365,7 @@ jobs:
       - name: Push to the AUR
         env:
           KEY: ${{ secrets.AUR_SSH_KEY }}
+          VER: ${{ needs.version.outputs.version }}
         run: |
           test -n "$KEY" || { echo "AUR_SSH_KEY secret missing, skipping"; exit 0; }
           mkdir -p ~/.ssh && chmod 700 ~/.ssh
@@ -272,7 +377,7 @@ jobs:
             cp "aur/$pkg/PKGBUILD" "aur/$pkg/.SRCINFO" "repo-$pkg/"
             ( cd "repo-$pkg"
               git add PKGBUILD .SRCINFO
-              git -c user.name="hcibridge release" -c user.email="henri.koski@bitbrewers.fi" commit -qm "$pkg ${GITHUB_REF_NAME#v}" || { echo "$pkg already current"; exit 0; }
+              git -c user.name="hcibridge release" -c user.email="henri.koski@bitbrewers.fi" commit -qm "$pkg $VER" || { echo "$pkg already current"; exit 0; }
               git push -q origin HEAD:master )
           done
 

--- a/build.zig
+++ b/build.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const zon = @import("build.zig.zon");
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
@@ -22,7 +23,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    const version = b.option([]const u8, "version", "version string baked into the binary") orelse "dev";
+    const version = b.option([]const u8, "version", "version string baked into the binary") orelse "v" ++ zon.version;
     const options = b.addOptions();
     options.addOption([]const u8, "version", version);
     const build_options = options.createModule();

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .hcibridge,
-    .version = "0.1.0",
+    .version = "1.0.1",
     .minimum_zig_version = "0.16.0",
     .fingerprint = 0x99423740dd9de94b,
     .paths = .{

--- a/packaging/APKBUILD.tmpl
+++ b/packaging/APKBUILD.tmpl
@@ -15,8 +15,8 @@ builddir="$srcdir/hcibridge-$pkgver"
 sha512sums="@SHA512@  $pkgname-$pkgver.tar.gz"
 
 build() {
-	zig build -Doptimize=ReleaseSafe "-Dversion=v$pkgver"
-	zig build gen "-Dversion=v$pkgver"
+	zig build -Doptimize=ReleaseSafe
+	zig build gen
 }
 
 package() {

--- a/packaging/PKGBUILD.tmpl
+++ b/packaging/PKGBUILD.tmpl
@@ -14,8 +14,8 @@ sha256sums=('@SHA256@')
 
 build() {
     cd "hcibridge-$pkgver"
-    zig build -Doptimize=ReleaseSafe "-Dversion=v$pkgver"
-    zig build gen "-Dversion=v$pkgver"
+    zig build -Doptimize=ReleaseSafe
+    zig build gen
 }
 
 package() {

--- a/packaging/void-template.tmpl
+++ b/packaging/void-template.tmpl
@@ -27,8 +27,8 @@ conf_files="/etc/hcibridge/config /etc/hcibridge/config.d/50-example.conf /etc/h
 
 do_build() {
 	export ZIG_GLOBAL_CACHE_DIR="${wrksrc}/zig-cache"
-	"${wrksrc}/${_zig}/zig" build -Doptimize=ReleaseSafe "-Dtarget=${XBPS_TARGET_MACHINE}-linux-musl" "-Dversion=v${version}"
-	"${wrksrc}/${_zig}/zig" build gen "-Dversion=v${version}"
+	"${wrksrc}/${_zig}/zig" build -Doptimize=ReleaseSafe "-Dtarget=${XBPS_TARGET_MACHINE}-linux-musl"
+	"${wrksrc}/${_zig}/zig" build gen
 }
 
 do_install() {

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+# Fails when a version is written in two places and the two disagree.
+# build.zig.zon is the source of truth for the project version and for Zig.
+# Usage: scripts/check-versions.sh
+set -eu
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+cd "$ROOT"
+
+CI=.github/workflows/ci.yml
+REL=.github/workflows/release.yml
+FW=scripts/firmware.sh
+VOID=packaging/void-template.tmpl
+
+fail=0
+bad() { echo "$@" >&2; fail=1; }
+
+# Sets VAL to the single value the pattern finds across the given files, or
+# reports what it found instead and leaves VAL empty.
+same() {
+    label=$1
+    pat=$2
+    shift 2
+    all=$(grep -hoE "$pat" "$@" | sort -u)
+    if [ "$(printf '%s\n' "$all" | grep -c .)" = 1 ]; then
+        VAL=$all
+    else
+        bad "$label: files disagree, found: $(printf '%s\n' "$all" | paste -sd,)"
+        VAL=""
+    fi
+}
+
+# Same, for a checksum identified by the file name it sits next to.
+sums() {
+    all=$(grep -h "$2" "$CI" "$REL" | grep -oE '[0-9a-f]{64}' | sort -u)
+    if [ "$(printf '%s\n' "$all" | grep -c .)" = 1 ]; then
+        VAL=$all
+    else
+        bad "$1: files disagree, found: $(printf '%s\n' "$all" | paste -sd,)"
+        VAL=""
+    fi
+}
+
+want() {
+    [ -n "$2" ] || return 0
+    [ "$2" = "$3" ] || bad "$1: $2, expected $3"
+}
+
+zon() { sed -n "s/^[[:space:]]*\.$1 = \"\([^\"]*\)\".*/\1/p" build.zig.zon; }
+
+VERSION=$(zon version)
+ZIG=$(zon minimum_zig_version)
+
+echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' \
+    || bad "build.zig.zon .version is \"$VERSION\", want a bare semver like 1.2.3"
+echo "$ZIG" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' \
+    || bad "build.zig.zon .minimum_zig_version is \"$ZIG\", want a bare semver"
+
+same "setup-zig" 'version: [0-9]+\.[0-9]+\.[0-9]+' "$CI" "$REL"
+want "setup-zig" "${VAL#version: }" "$ZIG"
+
+same "void template _zigver" '_zigver=[0-9]+\.[0-9]+\.[0-9]+' "$VOID"
+want "void template _zigver" "${VAL#_zigver=}" "$ZIG"
+
+same "Espressif Zig release" 'zig-espressif-bootstrap/releases/download/[0-9]+\.[0-9]+\.[0-9]+-xtensa' "$CI" "$REL" "$FW"
+want "Espressif Zig release" "${VAL##*/}" "$ZIG-xtensa"
+
+sums "Espressif Zig checksum" 'zig-xtensa.tar.xz'
+XSUM=$VAL
+same "Espressif Zig cache key" 'zig-xtensa-[0-9]+\.[0-9]+\.[0-9]+-xtensa-[0-9a-f]{8}' "$CI" "$REL"
+[ -z "$XSUM" ] || want "Espressif Zig cache key" "$VAL" "zig-xtensa-$ZIG-xtensa-$(echo "$XSUM" | cut -c1-8)"
+
+same "ESP-IDF image" 'espressif/idf:v[0-9.]+@sha256:[0-9a-f]{64}' "$CI" "$REL" "$FW"
+same "nfpm version" 'NV=[0-9]+\.[0-9]+\.[0-9]+' "$CI" "$REL"
+sums "nfpm checksum" 'nfpm.tgz'
+
+# The recipes take the version from the tarball's build.zig.zon. Passing it in
+# would let a recipe claim a version the source does not have.
+for f in packaging/*.tmpl; do
+    if grep -q -- '-Dversion' "$f"; then bad "$f passes -Dversion, let build.zig.zon decide"; fi
+done
+
+[ "$fail" = 0 ] || { echo "version check failed" >&2; exit 1; }
+echo "versions agree: hcibridge $VERSION, zig $ZIG"


### PR DESCRIPTION
Version came from the git tag, and `build.zig.zon` said `0.1.0`, which nothing read. A build from a release tarball reported `dev`.

Now the zon holds the version, `build.zig` reads it, and the recipes stop passing `-Dversion`. `release.yml` runs on push to main and releases the commit when `v<version>` has no release yet. The tag is pushed only after everything is built and installed, and the run is gated on the release rather than the tag, so a failed run can be re-run.

`scripts/check-versions.sh` catches the zig, ESP-IDF and nfpm versions drifting apart between files. It runs in a new `versions` job that also rejects a bump that is not higher than main or is already tagged.

Set to 1.0.1 since v1.0.0 is tagged, so merging cuts a release.