### PR TITLE
Harden the systemd unit

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .hcibridge,
-    .version = "1.0.1",
+    .version = "1.0.2",
     .minimum_zig_version = "0.16.0",
     .fingerprint = 0x99423740dd9de94b,
     .paths = .{

--- a/host/systemd/hcibridge.service
+++ b/host/systemd/hcibridge.service
@@ -1,16 +1,41 @@
 [Unit]
 Description=ESP HCI bridge daemon
 Documentation=https://github.com/heppu/hcibridge
-Wants=network-online.target
-After=network-online.target
+Wants=network-online.target modprobe@hci_vhci.service
+After=network-online.target modprobe@hci_vhci.service
 
 [Service]
 Type=simple
 EnvironmentFile=-/etc/default/hcibridge
-ExecStartPre=-/sbin/modprobe hci_vhci
 ExecStart=/usr/bin/hcibridge run $BRIDGE_ARGS
 Restart=always
 RestartSec=2
+
+NoNewPrivileges=yes
+CapabilityBoundingSet=CAP_NET_ADMIN
+DevicePolicy=closed
+DeviceAllow=/dev/vhci rw
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+ProtectProc=invisible
+ProcSubset=pid
+ProtectClock=yes
+ProtectHostname=yes
+ProtectControlGroups=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+UMask=0077
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The unit had no sandboxing at all, which is the first thing a Debian or Fedora reviewer asks about.

Adds the usual set: no new privileges, capabilities down to CAP_NET_ADMIN, only `/dev/vhci` allowed through `DevicePolicy=closed`, read-only file system, private tmp, kernel and proc protections, inet plus unix address families, and `@system-service` syscalls.

`ExecStartPre=-/sbin/modprobe hci_vhci` is gone so `ProtectKernelModules=yes` can stand. The module already comes from the shipped modules-load.d file at boot and from the deb and rpm postinstall, and `Wants=modprobe@hci_vhci.service` covers the start before either of those.

CI starts the service in Debian and Fedora systemd containers, but those cannot show a board attaching, so this wants a run on real hardware before it is trusted.