### PR TITLE
Run the test suite in the Arch, Alpine and Void recipes

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .hcibridge,
-    .version = "1.0.2",
+    .version = "1.0.3",
     .minimum_zig_version = "0.16.0",
     .fingerprint = 0x99423740dd9de94b,
     .paths = .{

--- a/packaging/APKBUILD.tmpl
+++ b/packaging/APKBUILD.tmpl
@@ -19,6 +19,10 @@ build() {
 	zig build gen
 }
 
+check() {
+	zig build test
+}
+
 package() {
 	install -Dm755 "$builddir"/zig-out/bin/hcibridge "$pkgdir"/usr/bin/hcibridge
 	install -Dm644 "$builddir"/zig-out/gen/hcibridge.1 "$pkgdir"/usr/share/man/man1/hcibridge.1

--- a/packaging/PKGBUILD.tmpl
+++ b/packaging/PKGBUILD.tmpl
@@ -18,6 +18,11 @@ build() {
     zig build gen
 }
 
+check() {
+    cd "hcibridge-$pkgver"
+    zig build test
+}
+
 package() {
     cd "hcibridge-$pkgver"
     install -Dm755 zig-out/bin/hcibridge "$pkgdir/usr/bin/hcibridge"

--- a/packaging/void-template.tmpl
+++ b/packaging/void-template.tmpl
@@ -31,6 +31,11 @@ do_build() {
 	"${wrksrc}/${_zig}/zig" build gen
 }
 
+do_check() {
+	export ZIG_GLOBAL_CACHE_DIR="${wrksrc}/zig-cache"
+	"${wrksrc}/${_zig}/zig" build test
+}
+
 do_install() {
 	vbin zig-out/bin/hcibridge
 	vman zig-out/gen/hcibridge.1


### PR DESCRIPTION
None of the recipes ran the tests. Arch, Alpine and Void all run a check phase when the recipe has one, and reviewers ask for it, so add `check()` to the PKGBUILD and the APKBUILD and `do_check()` to the Void template. The suite is offline and takes seconds. xbps-src skips do_check on cross builds, which is right since the tests have to run natively.

Verified against the v1.0.1 tag before pushing: makepkg built and checked and produced the package, and the suite passes under musl in an Alpine container (99 of 105 tests, 6 skipped). Void goes through verify-recipes at release time as usual.